### PR TITLE
refactor(auth): add basic authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,7 +61,7 @@ PLATFORM_KEYCLOAK_CLIENT_SECRET=
 # =============================================================================
 GUNICORN_BIND=0.0.0.0:8000
 # Leave unset for auto: min(2 * CPUs + 1, 8). Otherwise set a positive integer.
-WEB_CONCURRENCY=
+WEB_CONCURRENCY=2
 GUNICORN_TIMEOUT=120
 GUNICORN_GRACEFUL_TIMEOUT=30
 GUNICORN_KEEPALIVE=5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Per-tenant **`AUTH_MODE`** (`none` | `basic` | `keycloak`) for tenant API authentication.
+- **`basic`** mode: HTTP Basic auth backed by the `gwapi` schema (`gwapi.users`, roles, user CRUD via admin API).
+- Unified **`ApiUser`** identity with **`require_role()`** / **`require_authenticated()`** FastAPI dependencies.
+- [`app/schemas.py`](app/schemas.py) centralizes DDL bootstrap for `log` and `gwapi` schemas.
 - Install script for production deployment (single-tenant)
+
+### Deprecated
+
+- **`KEYCLOAK_ENABLED`** per-tenant env var (shim maps to `AUTH_MODE`; removal in **2.0.0**, `# DEPRECATED #22`).
+- Admin API top-level **`keycloak`** block (use **`auth.mode`** + **`auth.keycloak`**).
 
 ## [1.3.2] - 2026-06-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Per-tenant **`AUTH_MODE`** (`none` | `basic` | `keycloak`) for tenant API authentication.
 - **`basic`** mode: HTTP Basic auth backed by the `gwapi` schema (`gwapi.users`, roles, user CRUD via admin API).
-- Unified **`ApiUser`** identity with **`require_role()`** / **`require_authenticated()`** FastAPI dependencies.
+- Unified **`ApiUser`** identity with **`require_role()`** FastAPI dependency.
 - [`app/schemas.py`](app/schemas.py) centralizes DDL bootstrap for `log` and `gwapi` schemas.
 - Install script for production deployment (single-tenant)
 

--- a/README.md
+++ b/README.md
@@ -197,11 +197,27 @@ Mutations gated by `ADMIN_WRITE_ENABLED=true`; full-dir reload also gated by `AD
 <a id="authentication"></a>
 ## 🔐 Authentication
 
-Keycloak integration is **per tenant** and optional. When the tenant has `KEYCLOAK_ENABLED=true`:
+Tenant API auth is controlled per tenant by **`AUTH_MODE`**:
+
+| Mode | Behavior |
+|------|----------|
+| `none` (default) | Anonymous access — same as 1.3.x with `KEYCLOAK_ENABLED=false` |
+| `keycloak` | Bearer JWT from the tenant Keycloak realm |
+| `basic` | HTTP Basic (`Authorization: Basic …`) validated against `gwapi.users` in the tenant DB |
+
+**Migration from 1.3.x:** no config change required. `KEYCLOAK_ENABLED=true` → `keycloak`, `false` → `none`. Set `AUTH_MODE` explicitly when convenient; `KEYCLOAK_ENABLED` is deprecated (removed in 2.0.0).
+
+**Basic auth:** users live in the tenant Postgres (`gwapi` schema). Each user has a `db_role` that must exist as a PostgreSQL role (`SET ROLE`). Manage users via admin API: `${API_ROOT}/admin/tenants/{id}/users` (requires tenant `AUTH_MODE=basic`).
+
+Optional bootstrap: `AUTH_BASIC_BOOTSTRAP_USER` / `AUTH_BASIC_BOOTSTRAP_PASSWORD` create the first user when the table is empty.
+
+**Role checks:** inject `Depends(require_role("role_om", "role_master"))` on routes; roles come from Keycloak JWT claims or `gwapi.user_roles` in basic mode.
+
+Keycloak integration details (unchanged for `AUTH_MODE=keycloak`):
 - Endpoints require a valid `Authorization: Bearer <token>` issued by the tenant's realm.
 - Tokens are decoded against the tenant idp's RS256 public key (no realm round-trip per request).
 
-When disabled, endpoints accept anonymous requests for that tenant.
+When disabled (`AUTH_MODE=none`), endpoints accept anonymous requests for that tenant.
 
 `/admin/*` uses a separate **platform** Keycloak realm (`PLATFORM_KEYCLOAK_*`) plus HTTP Basic, with `platform-admin` as the required role.
 
@@ -262,7 +278,7 @@ curl -fsSL https://raw.githubusercontent.com/Giswater/giswater-api/main/deploy/i
 
 Creates `/opt/giswater-api` with production Compose, `.env` (`SINGLE_TENANT_ID=main`), and `config/tenants/main.env`. See [deploy/README.md](deploy/README.md).
 
-Pin a release: `GISWATER_API_REF=v1.3.2 curl -fsSL ... | sudo bash`
+Pin deploy templates: `GISWATER_API_REF=v1.3.2 curl -fsSL ... | sudo bash` (Docker image tag is prompted separately).
 
 - Keep `proxy_set_header Host $host` at the reverse proxy (`deploy/nginx.conf.example`) because tenant resolution depends on `Host`.
 - Apex host (`BASE_DOMAIN`) serves only `${API_ROOT}/admin/*`; tenant hosts (`<tenant>.<BASE_DOMAIN>`) serve `${API_ROOT}/v1/*`.

--- a/app/auth.py
+++ b/app/auth.py
@@ -106,17 +106,8 @@ def get_current_user_dep():
     return get_current_user
 
 
-def require_authenticated():
-    async def _check(user: Annotated[ApiUser, Depends(get_current_user)]) -> ApiUser:
-        if user.is_anonymous:
-            raise HTTPException(status_code=403, detail="Authentication required")
-        return user
-
-    return _check
-
-
 def require_role(*roles: str):
-    """403 when the current user lacks any of the given roles (skipped for anonymous)."""
+    """403 when the current user lacks any of the given roles (skipped for anonymous users)."""
 
     async def _check(user: Annotated[ApiUser, Depends(get_current_user)]) -> ApiUser:
         if user.is_anonymous:

--- a/app/auth.py
+++ b/app/auth.py
@@ -8,15 +8,17 @@ or (at your option) any later version.
 import asyncio
 import secrets
 import time
-from typing import Optional
+from typing import Annotated, Optional
 
 import httpx
 import jwt
 from fastapi import Depends, HTTPException, Request
 from fastapi.security import HTTPBasic, HTTPBasicCredentials
-from fastapi_keycloak import FastAPIKeycloak, OIDCUser
+from fastapi_keycloak import FastAPIKeycloak
 
 from .config import global_settings
+from .gwapi_users import verify_credentials
+from .models.auth_models import ApiUser
 
 _basic = HTTPBasic(auto_error=False)
 
@@ -26,10 +28,18 @@ _platform_jwks_cache: dict[str, tuple[float, dict]] = {}
 _platform_jwks_lock = asyncio.Lock()
 
 
-def verify_token(token: str, idp: FastAPIKeycloak) -> OIDCUser:
-    """Decode a tenant-issued JWT against the tenant's Keycloak public key.
+def _roles_from_jwt_payload(payload: dict, client_id: str | None) -> frozenset[str]:
+    roles: set[str] = set()
+    realm_roles = (payload.get("realm_access") or {}).get("roles") or []
+    roles.update(realm_roles)
+    if client_id:
+        resource = (payload.get("resource_access") or {}).get(client_id) or {}
+        roles.update(resource.get("roles") or [])
+    return frozenset(roles)
 
-    Avoids the lib's private `_decode_token` so we don't depend on internals."""
+
+def verify_token(token: str, idp: FastAPIKeycloak) -> ApiUser:
+    """Decode a tenant-issued JWT against the tenant's Keycloak public key."""
     try:
         payload = jwt.decode(
             token,
@@ -39,30 +49,83 @@ def verify_token(token: str, idp: FastAPIKeycloak) -> OIDCUser:
         )
     except jwt.PyJWTError as exc:
         raise HTTPException(status_code=401, detail="Invalid token") from exc
-    return OIDCUser.model_validate(payload)
+    username = payload.get("preferred_username") or payload.get("sub") or "unknown"
+    return ApiUser(
+        sub=str(payload.get("sub") or username),
+        preferred_username=str(username),
+        auth_method="keycloak",
+        roles=_roles_from_jwt_payload(payload, idp.client_id),
+        db_role=str(username),
+    )
 
 
-def get_current_user_dep():
-    """Return a dependency that resolves the current user from the per-tenant idp."""
+async def get_current_user(
+    request: Request,
+    credentials: Optional[HTTPBasicCredentials] = Depends(_basic),
+) -> ApiUser:
+    """Resolve the authenticated tenant API user."""
+    tenant = getattr(request.state, "tenant", None)
+    if tenant is None:
+        return ApiUser.anonymous()
 
-    async def _resolve(request: Request) -> OIDCUser:
-        tenant = getattr(request.state, "tenant", None)
-        if tenant is None or tenant.idp is None:
-            return OIDCUser(
-                sub="anonymous",
-                iat=0,
-                exp=0,
-                email=None,
-                email_verified=False,
-                preferred_username="anonymous",
-            )
+    auth_mode = tenant.settings.auth_mode
+    if auth_mode == "none":
+        return ApiUser.anonymous()
+
+    if auth_mode == "keycloak":
+        if tenant.idp is None:
+            raise HTTPException(status_code=500, detail="Keycloak not configured for tenant")
         auth = request.headers.get("authorization") or ""
         if not auth.lower().startswith("bearer "):
             raise HTTPException(status_code=401, detail="Missing bearer token")
         token = auth.split(" ", 1)[1].strip()
         return verify_token(token, tenant.idp)
 
-    return _resolve
+    if auth_mode == "basic":
+        if credentials is None:
+            raise HTTPException(
+                status_code=401,
+                detail="Missing basic credentials",
+                headers={"WWW-Authenticate": 'Basic realm="tenant"'},
+            )
+        user = await verify_credentials(tenant.db_manager, credentials.username, credentials.password)
+        if user is None:
+            raise HTTPException(
+                status_code=401,
+                detail="Invalid credentials",
+                headers={"WWW-Authenticate": 'Basic realm="tenant"'},
+            )
+        return user
+
+    raise HTTPException(status_code=500, detail=f"Unsupported auth mode '{auth_mode}'")
+
+
+# DEPRECATED #22: remove in 2.0.0; use Depends(get_current_user) directly
+def get_current_user_dep():
+    """Backward-compatible factory; prefer Depends(get_current_user)."""
+    return get_current_user
+
+
+def require_authenticated():
+    async def _check(user: Annotated[ApiUser, Depends(get_current_user)]) -> ApiUser:
+        if user.is_anonymous:
+            raise HTTPException(status_code=403, detail="Authentication required")
+        return user
+
+    return _check
+
+
+def require_role(*roles: str):
+    """403 when the current user lacks any of the given roles (skipped for anonymous)."""
+
+    async def _check(user: Annotated[ApiUser, Depends(get_current_user)]) -> ApiUser:
+        if user.is_anonymous:
+            return user
+        if not user.has_any_role(roles):
+            raise HTTPException(status_code=403, detail="Insufficient role")
+        return user
+
+    return _check
 
 
 async def _platform_jwks() -> dict:

--- a/app/auth_constants.py
+++ b/app/auth_constants.py
@@ -1,0 +1,21 @@
+"""
+Copyright © 2026 by BGEO. All rights reserved.
+The program is free software: you can redistribute it and/or modify it under the terms of the GNU
+General Public License as published by the Free Software Foundation, either version 3 of the License,
+or (at your option) any later version.
+"""
+
+# Tracks 2.0.0 cleanup: grep `DEPRECATED #22` (github.com/Giswater/giswater-api/issues/22).
+DEPRECATED_KEYCLOAK_ENABLED_ISSUE = "22"
+
+AUTH_MODES = frozenset({"none", "basic", "keycloak"})
+
+GWAPI_DEFAULT_ROLES: tuple[tuple[str, str], ...] = (
+    ("role_basic", "Basic read access"),
+    ("role_edit", "Edit access"),
+    ("role_om", "Operations and maintenance"),
+    ("role_epa", "EPA / scenario access"),
+    ("role_master", "Master access"),
+)
+
+MIN_PASSWORD_LENGTH = 8

--- a/app/config.py
+++ b/app/config.py
@@ -5,13 +5,20 @@ General Public License as published by the Free Software Foundation, either vers
 or (at your option) any later version.
 """
 
+import logging
 import os
 import re
+import warnings
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Mapping
+from typing import Literal, Mapping
 
 from dotenv import dotenv_values, load_dotenv
+
+from .auth_constants import AUTH_MODES, DEPRECATED_KEYCLOAK_ENABLED_ISSUE
+
+logger = logging.getLogger(__name__)
+AuthMode = Literal["none", "basic", "keycloak"]
 
 # Mirror of `app.tenant.TENANT_ID_RE` / `RESERVED_IDS` (kept here to avoid a
 # circular import: `app.tenant` imports from this module).
@@ -173,8 +180,12 @@ class TenantSettings:
     db_pool_max_idle: float = 300.0
     db_connect_timeout: float = 5.0
 
-    # Keycloak
-    keycloak_enabled: bool = False
+    # Tenant API authentication
+    auth_mode: AuthMode = "none"
+    auth_basic_bootstrap_user: str | None = None
+    auth_basic_bootstrap_password: str | None = None
+
+    # Keycloak (required when auth_mode == "keycloak")
     keycloak_url: str | None = None
     keycloak_realm: str | None = None
     keycloak_client_id: str | None = None
@@ -183,8 +194,12 @@ class TenantSettings:
     keycloak_admin_client_secret: str | None = None
     keycloak_callback_uri: str | None = None
 
+    @property
+    def keycloak_enabled(self) -> bool:
+        return self.auth_mode == "keycloak"
+
     def validate(self) -> None:
-        if self.keycloak_enabled:
+        if self.auth_mode == "keycloak":
             missing = [
                 name
                 for name, value in (
@@ -200,6 +215,32 @@ class TenantSettings:
             ]
             if missing:
                 raise ValueError(f"Keycloak configuration is incomplete: {', '.join(missing)}")
+        if self.auth_mode not in AUTH_MODES:
+            raise ValueError(f"Invalid AUTH_MODE '{self.auth_mode}'")
+
+
+def _resolve_auth_mode(env: Mapping[str, str | None]) -> AuthMode:
+    auth_mode_raw = (env.get("AUTH_MODE") or "").strip().lower()
+    if auth_mode_raw in AUTH_MODES:
+        return auth_mode_raw  # type: ignore[return-value]
+
+    # DEPRECATED #22: entire block below (KEYCLOAK_ENABLED env fallback); remove in 2.0.0
+    if env.get("AUTH_MODE") is None and env.get("KEYCLOAK_ENABLED") is not None:
+        warnings.warn(
+            "KEYCLOAK_ENABLED is deprecated; set AUTH_MODE=keycloak|basic|none. "
+            f"Removal in giswater-api 2.0.0 (#{DEPRECATED_KEYCLOAK_ENABLED_ISSUE}).",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+        logger.info(
+            "KEYCLOAK_ENABLED is deprecated; set AUTH_MODE explicitly. Removal in giswater-api 2.0.0 (#%s).",
+            DEPRECATED_KEYCLOAK_ENABLED_ISSUE,
+        )
+    if _to_bool(env.get("KEYCLOAK_ENABLED"), False):
+        return "keycloak"
+    # END DEPRECATED #22
+
+    return "none"
 
 
 def _build_global(env: Mapping[str, str | None]) -> GlobalSettings:
@@ -258,7 +299,9 @@ def _build_tenant(env: Mapping[str, str | None]) -> TenantSettings:
         db_pool_max_waiting=_to_int(env.get("DB_POOL_MAX_WAITING"), 0),
         db_pool_max_idle=_to_float(env.get("DB_POOL_MAX_IDLE"), 300.0),
         db_connect_timeout=_to_float(env.get("DB_CONNECT_TIMEOUT"), 5.0),
-        keycloak_enabled=_to_bool(env.get("KEYCLOAK_ENABLED"), False),
+        auth_mode=_resolve_auth_mode(env),
+        auth_basic_bootstrap_user=env.get("AUTH_BASIC_BOOTSTRAP_USER") or None,
+        auth_basic_bootstrap_password=env.get("AUTH_BASIC_BOOTSTRAP_PASSWORD") or None,
         keycloak_url=env.get("KEYCLOAK_URL") or None,
         keycloak_realm=env.get("KEYCLOAK_REALM") or None,
         keycloak_client_id=env.get("KEYCLOAK_CLIENT_ID") or None,

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -12,6 +12,7 @@ from fastapi import Depends, Header, HTTPException, Query, Request
 from .auth import get_current_user
 from .models.auth_models import ApiUser
 from .tenant import Tenant
+from .utils.utils import DB_IDENTITY_CTX, DbIdentity
 
 
 def _get_tenant(request: Request) -> Tenant:
@@ -59,11 +60,19 @@ async def common_parameters(
     ),
 ):
     tenant = _get_tenant(request)
+    if current_user.is_anonymous:
+        identity = DbIdentity(username=None, db_role=None)
+    else:
+        identity = DbIdentity(
+            username=current_user.preferred_username,
+            db_role=_db_role_for_user(current_user),
+        )
+    DB_IDENTITY_CTX.set(identity)
     return {
         "request": request,
         "user": current_user,
         "user_id": current_user.preferred_username,
-        "db_role": _db_role_for_user(current_user),
+        "db_role": identity.db_role,
         "schema": schema,
         "device": device,
         "lang": lang,

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -8,9 +8,9 @@ or (at your option) any later version.
 from typing import Annotated, Literal
 
 from fastapi import Depends, Header, HTTPException, Query, Request
-from fastapi_keycloak import OIDCUser
 
-from .auth import get_current_user_dep
+from .auth import get_current_user
+from .models.auth_models import ApiUser
 from .tenant import Tenant
 
 
@@ -32,9 +32,15 @@ async def get_schema(
     return schema
 
 
+def _db_role_for_user(user: ApiUser) -> str | None:
+    if user.is_anonymous:
+        return None
+    return user.db_role or user.preferred_username
+
+
 async def common_parameters(
     request: Request,
-    current_user: OIDCUser = Depends(get_current_user_dep()),  # noqa: B008
+    current_user: Annotated[ApiUser, Depends(get_current_user)],
     schema: str = Depends(get_schema),
     device: int = Header(
         default=5,
@@ -55,7 +61,9 @@ async def common_parameters(
     tenant = _get_tenant(request)
     return {
         "request": request,
+        "user": current_user,
         "user_id": current_user.preferred_username,
+        "db_role": _db_role_for_user(current_user),
         "schema": schema,
         "device": device,
         "lang": lang,

--- a/app/gwapi_users.py
+++ b/app/gwapi_users.py
@@ -14,6 +14,7 @@ from typing import Any
 
 import bcrypt
 from psycopg import sql
+from psycopg.errors import UniqueViolation
 from psycopg.rows import dict_row
 
 from .config import TenantSettings
@@ -204,10 +205,11 @@ async def create_user(
                         (user_id, role_name),
                     )
             await conn.commit()
-        except Exception as exc:
+        except UniqueViolation as exc:
             await conn.rollback()
-            if "duplicate key" in str(exc).lower():
-                raise GwapiUserError(f"User '{username}' already exists") from exc
+            raise GwapiUserError(f"User '{username}' already exists") from exc
+        except Exception:
+            await conn.rollback()
             raise
     record = await get_user(db_manager, username)
     if record is None:

--- a/app/gwapi_users.py
+++ b/app/gwapi_users.py
@@ -1,0 +1,319 @@
+"""
+Copyright © 2026 by BGEO. All rights reserved.
+The program is free software: you can redistribute it and/or modify it under the terms of the GNU
+General Public License as published by the Free Software Foundation, either version 3 of the License,
+or (at your option) any later version.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+import bcrypt
+from psycopg import sql
+from psycopg.rows import dict_row
+
+from .config import TenantSettings
+from .auth_constants import MIN_PASSWORD_LENGTH
+from .models.auth_models import ApiUser
+from .schemas import GWAPI_ROLES_TABLE, GWAPI_SCHEMA, GWAPI_USER_ROLES_TABLE, GWAPI_USERS_TABLE
+
+logger = logging.getLogger(__name__)
+
+
+class GwapiUserError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class GwapiUserRecord:
+    id: int
+    username: str
+    db_role: str
+    enabled: bool
+    roles: frozenset[str]
+    created_at: datetime
+    updated_at: datetime
+
+
+def _hash_password(password: str) -> str:
+    if len(password) < MIN_PASSWORD_LENGTH:
+        raise GwapiUserError(f"Password must be at least {MIN_PASSWORD_LENGTH} characters")
+    hashed = bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt())
+    return hashed.decode("utf-8")
+
+
+def _check_password(password: str, password_hash: str) -> bool:
+    try:
+        return bcrypt.checkpw(password.encode("utf-8"), password_hash.encode("utf-8"))
+    except ValueError:
+        return False
+
+
+def _record_to_api_user(record: GwapiUserRecord) -> ApiUser:
+    return ApiUser(
+        sub=str(record.id),
+        preferred_username=record.username,
+        auth_method="basic",
+        roles=record.roles,
+        db_role=record.db_role,
+    )
+
+
+async def validate_db_role(db_manager, role_name: str) -> bool:
+    async with db_manager.get_db() as conn:
+        if conn is None:
+            return False
+        async with conn.cursor() as cursor:
+            await cursor.execute("SELECT 1 FROM pg_roles WHERE rolname = %s", (role_name,))
+            row = await cursor.fetchone()
+            return row is not None
+
+
+async def list_roles(db_manager) -> list[dict[str, str]]:
+    async with db_manager.get_db() as conn:
+        if conn is None:
+            return []
+        async with conn.cursor(row_factory=dict_row) as cursor:
+            await cursor.execute(
+                sql.SQL("SELECT name, description FROM {}.{} ORDER BY name").format(
+                    sql.Identifier(GWAPI_SCHEMA),
+                    sql.Identifier(GWAPI_ROLES_TABLE),
+                )
+            )
+            rows = await cursor.fetchall()
+            return [{"name": row["name"], "description": row.get("description")} for row in rows]
+
+
+async def _load_roles_for_user(conn, user_id: int) -> frozenset[str]:
+    async with conn.cursor(row_factory=dict_row) as cursor:
+        await cursor.execute(
+            sql.SQL("SELECT role_name FROM {}.{} WHERE user_id = %s").format(
+                sql.Identifier(GWAPI_SCHEMA),
+                sql.Identifier(GWAPI_USER_ROLES_TABLE),
+            ),
+            (user_id,),
+        )
+        rows = await cursor.fetchall()
+        return frozenset(row["role_name"] for row in rows)
+
+
+async def _row_to_record(conn, row: dict[str, Any]) -> GwapiUserRecord:
+    roles = await _load_roles_for_user(conn, row["id"])
+    return GwapiUserRecord(
+        id=row["id"],
+        username=row["username"],
+        db_role=row["db_role"],
+        enabled=row["enabled"],
+        roles=roles,
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+    )
+
+
+async def list_users(db_manager) -> list[GwapiUserRecord]:
+    async with db_manager.get_db() as conn:
+        if conn is None:
+            return []
+        async with conn.cursor(row_factory=dict_row) as cursor:
+            await cursor.execute(
+                sql.SQL(
+                    "SELECT id, username, db_role, enabled, created_at, updated_at FROM {}.{} ORDER BY username"
+                ).format(sql.Identifier(GWAPI_SCHEMA), sql.Identifier(GWAPI_USERS_TABLE))
+            )
+            rows = await cursor.fetchall()
+            return [await _row_to_record(conn, row) for row in rows]
+
+
+async def get_user(db_manager, username: str) -> GwapiUserRecord | None:
+    async with db_manager.get_db() as conn:
+        if conn is None:
+            return None
+        async with conn.cursor(row_factory=dict_row) as cursor:
+            await cursor.execute(
+                sql.SQL(
+                    "SELECT id, username, db_role, enabled, created_at, updated_at FROM {}.{} WHERE username = %s"
+                ).format(sql.Identifier(GWAPI_SCHEMA), sql.Identifier(GWAPI_USERS_TABLE)),
+                (username,),
+            )
+            row = await cursor.fetchone()
+            if row is None:
+                return None
+            return await _row_to_record(conn, row)
+
+
+async def verify_credentials(db_manager, username: str, password: str) -> ApiUser | None:
+    async with db_manager.get_db() as conn:
+        if conn is None:
+            return None
+        async with conn.cursor(row_factory=dict_row) as cursor:
+            await cursor.execute(
+                sql.SQL(
+                    "SELECT id, username, password_hash, db_role, enabled, created_at, updated_at FROM {}.{} "
+                    "WHERE username = %s"
+                ).format(sql.Identifier(GWAPI_SCHEMA), sql.Identifier(GWAPI_USERS_TABLE)),
+                (username,),
+            )
+            row = await cursor.fetchone()
+            if row is None or not row["enabled"]:
+                return None
+            if not _check_password(password, row["password_hash"]):
+                return None
+            record = await _row_to_record(conn, row)
+            return _record_to_api_user(record)
+
+
+async def create_user(
+    db_manager,
+    *,
+    username: str,
+    password: str,
+    db_role: str | None,
+    roles: list[str],
+    enabled: bool = True,
+) -> GwapiUserRecord:
+    effective_db_role = db_role or username
+    if not await validate_db_role(db_manager, effective_db_role):
+        raise GwapiUserError(f"PostgreSQL role '{effective_db_role}' does not exist")
+    password_hash = _hash_password(password)
+    async with db_manager.get_db() as conn:
+        if conn is None:
+            raise GwapiUserError("Database unavailable")
+        try:
+            async with conn.cursor(row_factory=dict_row) as cursor:
+                await cursor.execute(
+                    sql.SQL(
+                        """
+                        INSERT INTO {}.{} (username, password_hash, db_role, enabled)
+                        VALUES (%s, %s, %s, %s)
+                        RETURNING id, username, db_role, enabled, created_at, updated_at
+                        """
+                    ).format(sql.Identifier(GWAPI_SCHEMA), sql.Identifier(GWAPI_USERS_TABLE)),
+                    (username, password_hash, effective_db_role, enabled),
+                )
+                row = await cursor.fetchone()
+                user_id = row["id"]
+                for role_name in roles:
+                    await cursor.execute(
+                        sql.SQL("INSERT INTO {}.{} (user_id, role_name) VALUES (%s, %s) ON CONFLICT DO NOTHING").format(
+                            sql.Identifier(GWAPI_SCHEMA), sql.Identifier(GWAPI_USER_ROLES_TABLE)
+                        ),
+                        (user_id, role_name),
+                    )
+            await conn.commit()
+        except Exception as exc:
+            await conn.rollback()
+            if "duplicate key" in str(exc).lower():
+                raise GwapiUserError(f"User '{username}' already exists") from exc
+            raise
+    record = await get_user(db_manager, username)
+    if record is None:
+        raise GwapiUserError("Failed to create user")
+    return record
+
+
+async def update_user(
+    db_manager,
+    username: str,
+    *,
+    password: str | None = None,
+    db_role: str | None = None,
+    roles: list[str] | None = None,
+    enabled: bool | None = None,
+) -> GwapiUserRecord:
+    existing = await get_user(db_manager, username)
+    if existing is None:
+        raise GwapiUserError(f"User '{username}' not found")
+
+    new_db_role = db_role if db_role is not None else existing.db_role
+    if not await validate_db_role(db_manager, new_db_role):
+        raise GwapiUserError(f"PostgreSQL role '{new_db_role}' does not exist")
+
+    async with db_manager.get_db() as conn:
+        if conn is None:
+            raise GwapiUserError("Database unavailable")
+        try:
+            async with conn.cursor() as cursor:
+                sets = ["updated_at = now()", "db_role = %s"]
+                params: list[Any] = [new_db_role]
+                if enabled is not None:
+                    sets.append("enabled = %s")
+                    params.append(enabled)
+                if password is not None:
+                    sets.append("password_hash = %s")
+                    params.append(_hash_password(password))
+                params.append(username)
+                await cursor.execute(
+                    sql.SQL("UPDATE {}.{} SET {} WHERE username = %s").format(
+                        sql.Identifier(GWAPI_SCHEMA),
+                        sql.Identifier(GWAPI_USERS_TABLE),
+                        sql.SQL(", ").join(sql.SQL(part) for part in sets),
+                    ),
+                    params,
+                )
+                if roles is not None:
+                    await cursor.execute(
+                        sql.SQL("DELETE FROM {}.{} WHERE user_id = %s").format(
+                            sql.Identifier(GWAPI_SCHEMA),
+                            sql.Identifier(GWAPI_USER_ROLES_TABLE),
+                        ),
+                        (existing.id,),
+                    )
+                    for role_name in roles:
+                        await cursor.execute(
+                            sql.SQL(
+                                "INSERT INTO {}.{} (user_id, role_name) VALUES (%s, %s) ON CONFLICT DO NOTHING"
+                            ).format(sql.Identifier(GWAPI_SCHEMA), sql.Identifier(GWAPI_USER_ROLES_TABLE)),
+                            (existing.id, role_name),
+                        )
+            await conn.commit()
+        except Exception:
+            await conn.rollback()
+            raise
+
+    record = await get_user(db_manager, username)
+    if record is None:
+        raise GwapiUserError("Failed to update user")
+    return record
+
+
+async def delete_user(db_manager, username: str) -> None:
+    async with db_manager.get_db() as conn:
+        if conn is None:
+            raise GwapiUserError("Database unavailable")
+        async with conn.cursor() as cursor:
+            await cursor.execute(
+                sql.SQL("DELETE FROM {}.{} WHERE username = %s").format(
+                    sql.Identifier(GWAPI_SCHEMA),
+                    sql.Identifier(GWAPI_USERS_TABLE),
+                ),
+                (username,),
+            )
+            if cursor.rowcount == 0:
+                raise GwapiUserError(f"User '{username}' not found")
+        await conn.commit()
+
+
+async def maybe_bootstrap_user(db_manager, settings: TenantSettings) -> None:
+    username = settings.auth_basic_bootstrap_user
+    password = settings.auth_basic_bootstrap_password
+    if not username or not password:
+        return
+    users = await list_users(db_manager)
+    if users:
+        return
+    try:
+        await create_user(
+            db_manager,
+            username=username,
+            password=password,
+            db_role=username,
+            roles=["role_basic"],
+            enabled=True,
+        )
+        logger.info("Bootstrapped basic auth user '%s'", username)
+    except GwapiUserError as exc:
+        logger.warning("Basic auth bootstrap failed for '%s': %s", username, exc)

--- a/app/keycloak.py
+++ b/app/keycloak.py
@@ -12,7 +12,7 @@ from .config import TenantSettings
 
 def build_idp(tenant_settings: TenantSettings) -> FastAPIKeycloak | None:
     """Build a Keycloak IDP for a tenant, or return None when disabled."""
-    if not tenant_settings.keycloak_enabled:
+    if tenant_settings.auth_mode != "keycloak":
         return None
     return FastAPIKeycloak(
         server_url=tenant_settings.keycloak_url,

--- a/app/logging.py
+++ b/app/logging.py
@@ -280,6 +280,7 @@ async def request_logging_middleware(request: Request, call_next):
     request_id = uuid.uuid4()
     request.state.request_id = request_id
     token = utils.REQUEST_ID_CTX.set(request_id)
+    utils.DB_IDENTITY_CTX.set(None)
     request_body = await request.body()
 
     response = None
@@ -299,6 +300,7 @@ async def request_logging_middleware(request: Request, call_next):
         raise
     finally:
         utils.REQUEST_ID_CTX.reset(token)
+        utils.DB_IDENTITY_CTX.set(None)
         duration_ms = int((time.monotonic() - start) * 1000)
         path = request.url.path
         skip_body_path = any(prefix in path for prefix in _SKIP_BODY_PREFIXES)

--- a/app/main.py
+++ b/app/main.py
@@ -34,7 +34,7 @@ from .exceptions import (
 from .host_middleware import host_middleware
 from .logging import request_logging_middleware
 from .models.util_models import GwErrorResponse
-from .routers import admin, system
+from .routers import admin, admin_users, system
 from .routers.basic import basic
 from .routers.crm import crm
 from .routers.epa import dscenario
@@ -208,6 +208,7 @@ admin_app = FastAPI(
     },
 )
 admin_app.include_router(admin.router)
+admin_app.include_router(admin_users.router)
 
 parent.mount(ADMIN_PREFIX, admin_app)
 parent.mount(TENANT_PREFIX, tenant_app)

--- a/app/models/admin_models.py
+++ b/app/models/admin_models.py
@@ -5,12 +5,14 @@ General Public License as published by the Free Software Foundation, either vers
 or (at your option) any later version.
 """
 
-from typing import Optional
+from typing import Literal, Optional
 
 from pydantic import BaseModel, Field
 
 from ..config import TenantSettings
 from ..tenant import Tenant
+
+AuthMode = Literal["none", "basic", "keycloak"]
 
 _REDACTED = "***"
 
@@ -52,7 +54,7 @@ class DbSettingsOut(BaseModel):
 
 
 class KeycloakSettingsIn(BaseModel):
-    enabled: bool = False
+    enabled: bool = False  # DEPRECATED #22: use auth.mode; remove in 2.0.0
     url: Optional[str] = None
     realm: Optional[str] = None
     client_id: Optional[str] = None
@@ -63,7 +65,7 @@ class KeycloakSettingsIn(BaseModel):
 
 
 class KeycloakSettingsOut(BaseModel):
-    enabled: bool
+    enabled: bool  # DEPRECATED #22: use auth.mode; remove in 2.0.0
     url: Optional[str] = None
     realm: Optional[str] = None
     client_id: Optional[str] = None
@@ -73,10 +75,29 @@ class KeycloakSettingsOut(BaseModel):
     callback_uri: Optional[str] = None
 
 
+class AuthSettingsIn(BaseModel):
+    mode: AuthMode = "none"
+    bootstrap_user: Optional[str] = Field(default=None, alias="bootstrapUser")
+    bootstrap_password: Optional[str] = Field(default=None, alias="bootstrapPassword")
+    keycloak: Optional[KeycloakSettingsIn] = None
+
+    model_config = {"populate_by_name": True}
+
+
+class AuthSettingsOut(BaseModel):
+    mode: AuthMode
+    bootstrap_user: Optional[str] = Field(default=None, alias="bootstrapUser")
+    bootstrap_password: Optional[str] = None  # _REDACTED or null
+    keycloak: Optional[KeycloakSettingsOut] = None
+
+    model_config = {"populate_by_name": True}
+
+
 class TenantIn(BaseModel):
     api: dict[str, bool] = Field(default_factory=dict)
     db: DbSettingsIn
-    keycloak: Optional[KeycloakSettingsIn] = None
+    auth: Optional[AuthSettingsIn] = None
+    keycloak: Optional[KeycloakSettingsIn] = None  # DEPRECATED #22: use auth.keycloak
 
 
 class TenantCreateIn(TenantIn):
@@ -93,7 +114,8 @@ class TenantOut(BaseModel):
     id: str
     api: dict[str, bool]
     db: DbSettingsOut
-    keycloak: Optional[KeycloakSettingsOut] = None
+    auth: AuthSettingsOut
+    keycloak: Optional[KeycloakSettingsOut] = None  # DEPRECATED #22: use auth.keycloak
     pool: PoolStatus
 
     @classmethod
@@ -125,8 +147,8 @@ class TenantOut(BaseModel):
             pool_max_idle=s.db_pool_max_idle,
             connect_timeout=s.db_connect_timeout,
         )
-        keycloak: Optional[KeycloakSettingsOut] = None
-        if s.keycloak_enabled or any(
+        keycloak_out: Optional[KeycloakSettingsOut] = None
+        if s.auth_mode == "keycloak" or any(
             (
                 s.keycloak_url,
                 s.keycloak_realm,
@@ -135,7 +157,7 @@ class TenantOut(BaseModel):
                 s.keycloak_callback_uri,
             )
         ):
-            keycloak = KeycloakSettingsOut(
+            keycloak_out = KeycloakSettingsOut(
                 enabled=s.keycloak_enabled,
                 url=s.keycloak_url,
                 realm=s.keycloak_realm,
@@ -145,13 +167,26 @@ class TenantOut(BaseModel):
                 admin_client_secret=_REDACTED if s.keycloak_admin_client_secret else None,
                 callback_uri=s.keycloak_callback_uri,
             )
+        auth = AuthSettingsOut(
+            mode=s.auth_mode,
+            bootstrapUser=s.auth_basic_bootstrap_user,
+            bootstrap_password=_REDACTED if s.auth_basic_bootstrap_password else None,
+            keycloak=keycloak_out if s.auth_mode == "keycloak" else None,
+        )
         pool = tenant.db_manager.connection_pool
         pool_status = PoolStatus(
             size=getattr(pool, "max_size", None) if pool is not None else None,
             in_use=None,
             healthy=pool is not None,
         )
-        return cls(id=tenant.id, api=api, db=db, keycloak=keycloak, pool=pool_status)
+        return cls(
+            id=tenant.id,
+            api=api,
+            db=db,
+            auth=auth,
+            keycloak=keycloak_out,  # DEPRECATED #22: duplicate of auth.keycloak; remove in 2.0.0
+            pool=pool_status,
+        )
 
 
 def build_tenant_settings_from_input(
@@ -171,10 +206,27 @@ def build_tenant_settings_from_input(
         return bool(getattr(existing, f"api_{name}", False)) if existing else False
 
     db = payload.db
-    kc = payload.keycloak
+    auth = payload.auth
+    # DEPRECATED #22: payload.keycloak fallback; remove in 2.0.0
+    kc = auth.keycloak if auth and auth.keycloak else payload.keycloak
 
     def _kept(new, old):
         return new if new is not None else old
+
+    if auth is not None:
+        auth_mode = auth.mode
+    elif kc and kc.enabled:
+        auth_mode = "keycloak"  # DEPRECATED #22: legacy keycloak.enabled; remove in 2.0.0
+    elif existing is not None:
+        auth_mode = existing.auth_mode
+    else:
+        auth_mode = "none"
+
+    bootstrap_user = auth.bootstrap_user if auth else None
+    bootstrap_password = auth.bootstrap_password if auth else None
+    if existing is not None:
+        bootstrap_user = _kept(bootstrap_user, existing.auth_basic_bootstrap_user)
+        bootstrap_password = _kept(bootstrap_password, existing.auth_basic_bootstrap_password)
 
     return TenantSettings(
         api_basic=_api("basic"),
@@ -199,7 +251,9 @@ def build_tenant_settings_from_input(
         db_pool_max_waiting=db.pool_max_waiting,
         db_pool_max_idle=db.pool_max_idle,
         db_connect_timeout=db.connect_timeout,
-        keycloak_enabled=bool(kc.enabled) if kc else False,
+        auth_mode=auth_mode,
+        auth_basic_bootstrap_user=bootstrap_user,
+        auth_basic_bootstrap_password=bootstrap_password,
         keycloak_url=kc.url if kc else None,
         keycloak_realm=kc.realm if kc else None,
         keycloak_client_id=kc.client_id if kc else None,

--- a/app/models/auth_models.py
+++ b/app/models/auth_models.py
@@ -1,0 +1,41 @@
+"""
+Copyright © 2026 by BGEO. All rights reserved.
+The program is free software: you can redistribute it and/or modify it under the terms of the GNU
+General Public License as published by the Free Software Foundation, either version 3 of the License,
+or (at your option) any later version.
+"""
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Literal
+
+AuthMethod = Literal["none", "keycloak", "basic"]
+
+
+@dataclass(frozen=True)
+class ApiUser:
+    """Unified tenant API identity for all auth modes."""
+
+    sub: str
+    preferred_username: str
+    auth_method: AuthMethod
+    roles: frozenset[str] = frozenset()
+    db_role: str | None = None
+
+    @property
+    def is_anonymous(self) -> bool:
+        return self.auth_method == "none"
+
+    def has_role(self, *names: str) -> bool:
+        return any(role in self.roles for role in names)
+
+    def has_any_role(self, names: Iterable[str]) -> bool:
+        return bool(self.roles.intersection(names))
+
+    @classmethod
+    def anonymous(cls) -> "ApiUser":
+        return cls(
+            sub="anonymous",
+            preferred_username="anonymous",
+            auth_method="none",
+        )

--- a/app/models/gwapi_user_models.py
+++ b/app/models/gwapi_user_models.py
@@ -1,0 +1,42 @@
+"""
+Copyright © 2026 by BGEO. All rights reserved.
+The program is free software: you can redistribute it and/or modify it under the terms of the GNU
+General Public License as published by the Free Software Foundation, either version 3 of the License,
+or (at your option) any later version.
+"""
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+AuthMode = Literal["none", "basic", "keycloak"]
+
+
+class GwapiRoleOut(BaseModel):
+    name: str
+    description: str | None = None
+
+
+class GwapiUserOut(BaseModel):
+    username: str
+    db_role: str
+    enabled: bool
+    roles: list[str]
+    created_at: datetime
+    updated_at: datetime
+
+
+class GwapiUserCreateIn(BaseModel):
+    username: str = Field(min_length=1, max_length=128)
+    password: str = Field(min_length=8)
+    db_role: str | None = Field(default=None, description="PostgreSQL role for SET ROLE; defaults to username")
+    enabled: bool = True
+    roles: list[str] = Field(default_factory=lambda: ["role_basic"])
+
+
+class GwapiUserUpdateIn(BaseModel):
+    password: str | None = Field(default=None, min_length=8)
+    db_role: str | None = None
+    enabled: bool | None = None
+    roles: list[str] | None = None

--- a/app/routers/admin_users.py
+++ b/app/routers/admin_users.py
@@ -1,0 +1,120 @@
+"""
+Copyright © 2026 by BGEO. All rights reserved.
+The program is free software: you can redistribute it and/or modify it under the terms of the GNU
+General Public License as published by the Free Software Foundation, either version 3 of the License,
+or (at your option) any later version.
+"""
+
+from fastapi import APIRouter, HTTPException, Request
+
+from .. import gwapi_users
+from ..gwapi_users import GwapiUserError
+from ..models.gwapi_user_models import GwapiRoleOut, GwapiUserCreateIn, GwapiUserOut, GwapiUserUpdateIn
+from ..tenant import TenantRegistry
+from .admin import _audit_log, _registry, _require_writes
+
+router = APIRouter(tags=["Admin - Users"])
+
+
+def _require_basic_auth_tenant(tid: str, registry: TenantRegistry):
+    tenant = registry.get(tid)
+    if tenant is None:
+        raise HTTPException(status_code=404, detail=f"Tenant '{tid}' not found")
+    if tenant.settings.auth_mode != "basic":
+        raise HTTPException(status_code=400, detail=f"Tenant '{tid}' is not configured for basic auth")
+    if tenant.db_manager.connection_pool is None:
+        raise HTTPException(status_code=503, detail=f"Tenant '{tid}' database unavailable")
+    return tenant
+
+
+def _to_out(record: gwapi_users.GwapiUserRecord) -> GwapiUserOut:
+    return GwapiUserOut(
+        username=record.username,
+        db_role=record.db_role,
+        enabled=record.enabled,
+        roles=sorted(record.roles),
+        created_at=record.created_at,
+        updated_at=record.updated_at,
+    )
+
+
+@router.get("/tenants/{tid}/roles", response_model=list[GwapiRoleOut])
+async def list_tenant_roles(tid: str, request: Request):
+    registry = _registry()
+    tenant = _require_basic_auth_tenant(tid, registry)
+    roles = await gwapi_users.list_roles(tenant.db_manager)
+    _audit_log(request, "list_roles", tid=tid)
+    return [GwapiRoleOut(**role) for role in roles]
+
+
+@router.get("/tenants/{tid}/users", response_model=list[GwapiUserOut])
+async def list_tenant_users(tid: str, request: Request):
+    registry = _registry()
+    tenant = _require_basic_auth_tenant(tid, registry)
+    users = await gwapi_users.list_users(tenant.db_manager)
+    _audit_log(request, "list_users", tid=tid)
+    return [_to_out(user) for user in users]
+
+
+@router.post("/tenants/{tid}/users", response_model=GwapiUserOut, status_code=201)
+async def create_tenant_user(tid: str, payload: GwapiUserCreateIn, request: Request):
+    _require_writes()
+    registry = _registry()
+    tenant = _require_basic_auth_tenant(tid, registry)
+    try:
+        user = await gwapi_users.create_user(
+            tenant.db_manager,
+            username=payload.username,
+            password=payload.password,
+            db_role=payload.db_role,
+            roles=payload.roles,
+            enabled=payload.enabled,
+        )
+    except GwapiUserError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    _audit_log(request, "create_user", tid=tid, username=payload.username)
+    return _to_out(user)
+
+
+@router.get("/tenants/{tid}/users/{username}", response_model=GwapiUserOut)
+async def get_tenant_user(tid: str, username: str, request: Request):
+    registry = _registry()
+    tenant = _require_basic_auth_tenant(tid, registry)
+    user = await gwapi_users.get_user(tenant.db_manager, username)
+    if user is None:
+        raise HTTPException(status_code=404, detail=f"User '{username}' not found")
+    _audit_log(request, "get_user", tid=tid, username=username)
+    return _to_out(user)
+
+
+@router.put("/tenants/{tid}/users/{username}", response_model=GwapiUserOut)
+async def update_tenant_user(tid: str, username: str, payload: GwapiUserUpdateIn, request: Request):
+    _require_writes()
+    registry = _registry()
+    tenant = _require_basic_auth_tenant(tid, registry)
+    try:
+        user = await gwapi_users.update_user(
+            tenant.db_manager,
+            username,
+            password=payload.password,
+            db_role=payload.db_role,
+            roles=payload.roles,
+            enabled=payload.enabled,
+        )
+    except GwapiUserError as exc:
+        status = 404 if "not found" in str(exc).lower() else 400
+        raise HTTPException(status_code=status, detail=str(exc)) from exc
+    _audit_log(request, "update_user", tid=tid, username=username)
+    return _to_out(user)
+
+
+@router.delete("/tenants/{tid}/users/{username}", status_code=204)
+async def delete_tenant_user(tid: str, username: str, request: Request):
+    _require_writes()
+    registry = _registry()
+    tenant = _require_basic_auth_tenant(tid, registry)
+    try:
+        await gwapi_users.delete_user(tenant.db_manager, username)
+    except GwapiUserError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    _audit_log(request, "delete_user", tid=tid, username=username)

--- a/app/routers/basic/basic.py
+++ b/app/routers/basic/basic.py
@@ -66,7 +66,6 @@ async def get_feature_changes(
         schema=commons["schema"],
         api_version=commons["api_version"],
         user=commons["user_id"],
-        db_role=commons["db_role"],
     )
     if not result:
         return {
@@ -290,7 +289,6 @@ async def get_arc_audit_values(
         schema=commons["schema"],
         api_version=commons["api_version"],
         user=commons["user_id"],
-        db_role=commons["db_role"],
     )
     return handle_procedure_result(result)
 

--- a/app/routers/basic/basic.py
+++ b/app/routers/basic/basic.py
@@ -66,6 +66,7 @@ async def get_feature_changes(
         schema=commons["schema"],
         api_version=commons["api_version"],
         user=commons["user_id"],
+        db_role=commons["db_role"],
     )
     if not result:
         return {
@@ -289,6 +290,7 @@ async def get_arc_audit_values(
         schema=commons["schema"],
         api_version=commons["api_version"],
         user=commons["user_id"],
+        db_role=commons["db_role"],
     )
     return handle_procedure_result(result)
 

--- a/app/routers/basic/basic.py
+++ b/app/routers/basic/basic.py
@@ -65,7 +65,6 @@ async def get_feature_changes(
         body,
         schema=commons["schema"],
         api_version=commons["api_version"],
-        user=commons["user_id"],
     )
     if not result:
         return {
@@ -288,7 +287,6 @@ async def get_arc_audit_values(
         body,
         schema=commons["schema"],
         api_version=commons["api_version"],
-        user=commons["user_id"],
     )
     return handle_procedure_result(result)
 

--- a/app/routers/epa/dscenario.py
+++ b/app/routers/epa/dscenario.py
@@ -73,7 +73,6 @@ async def create_dscenario(
         "gw_fct_create_dscenario_empty",
         body,
         schema=commons["schema"],
-        user=commons["user_id"],
         api_version=commons["api_version"],
     )
 
@@ -128,7 +127,6 @@ async def select_dscenario(
         data={"dscenario_id": dscenario_id},
         where_data={"cur_user": commons["user_id"]},
         schema=commons["schema"],
-        user=commons["user_id"],
     )
     db_version = await get_db_version(log, commons["db_manager"], schema=commons["schema"])
     return {
@@ -167,7 +165,6 @@ async def delete_dscenario(
         table_name=table_name,
         where_data=where_data,
         schema=commons["schema"],
-        user=commons["user_id"],
     )
 
     if not status:
@@ -259,7 +256,6 @@ async def insert_dscenario_objects(
             table_name=table_name,
             data=obj,
             schema=commons["schema"],
-            user=commons["user_id"],
         )
         all_rows.extend(rows)
 
@@ -321,7 +317,6 @@ async def upsert_dscenario_objects(
             data=row,
             where_data=where_data,
             schema=commons["schema"],
-            user=commons["user_id"],
         )
         all_rows.extend(rows)
 
@@ -367,7 +362,6 @@ async def get_dscenario_object(
         where_clause="dscenario_id = %s AND {} = %s".format(id_column),
         parameters=(dscenario_id, object_id),
         schema=commons["schema"],
-        user=commons["user_id"],
     )
 
     if not rows:
@@ -426,7 +420,6 @@ async def update_dscenario_object(
         data=update_data,
         where_data=where_data,
         schema=commons["schema"],
-        user=commons["user_id"],
     )
 
     if not rows:
@@ -479,7 +472,6 @@ async def upsert_dscenario_object(
         data=upsert_data,
         where_data=where_data,
         schema=commons["schema"],
-        user=commons["user_id"],
     )
     message_text = "Object inserted" if op == "inserted" else "Object updated"
 
@@ -526,7 +518,6 @@ async def delete_dscenario_object(
         table_name=table_name,
         where_data=where_data,
         schema=commons["schema"],
-        user=commons["user_id"],
     )
 
     if not status:

--- a/app/routers/epa/dscenario.py
+++ b/app/routers/epa/dscenario.py
@@ -74,6 +74,7 @@ async def create_dscenario(
         body,
         schema=commons["schema"],
         user=commons["user_id"],
+        db_role=commons["db_role"],
         api_version=commons["api_version"],
     )
 
@@ -129,6 +130,7 @@ async def select_dscenario(
         where_data={"cur_user": commons["user_id"]},
         schema=commons["schema"],
         user=commons["user_id"],
+        db_role=commons["db_role"],
     )
     db_version = await get_db_version(log, commons["db_manager"], schema=commons["schema"])
     return {
@@ -168,6 +170,7 @@ async def delete_dscenario(
         where_data=where_data,
         schema=commons["schema"],
         user=commons["user_id"],
+        db_role=commons["db_role"],
     )
 
     if not status:
@@ -260,6 +263,7 @@ async def insert_dscenario_objects(
             data=obj,
             schema=commons["schema"],
             user=commons["user_id"],
+            db_role=commons["db_role"],
         )
         all_rows.extend(rows)
 
@@ -322,6 +326,7 @@ async def upsert_dscenario_objects(
             where_data=where_data,
             schema=commons["schema"],
             user=commons["user_id"],
+            db_role=commons["db_role"],
         )
         all_rows.extend(rows)
 
@@ -368,6 +373,7 @@ async def get_dscenario_object(
         parameters=(dscenario_id, object_id),
         schema=commons["schema"],
         user=commons["user_id"],
+        db_role=commons["db_role"],
     )
 
     if not rows:
@@ -427,6 +433,7 @@ async def update_dscenario_object(
         where_data=where_data,
         schema=commons["schema"],
         user=commons["user_id"],
+        db_role=commons["db_role"],
     )
 
     if not rows:
@@ -480,6 +487,7 @@ async def upsert_dscenario_object(
         where_data=where_data,
         schema=commons["schema"],
         user=commons["user_id"],
+        db_role=commons["db_role"],
     )
     message_text = "Object inserted" if op == "inserted" else "Object updated"
 
@@ -527,6 +535,7 @@ async def delete_dscenario_object(
         where_data=where_data,
         schema=commons["schema"],
         user=commons["user_id"],
+        db_role=commons["db_role"],
     )
 
     if not status:

--- a/app/routers/epa/dscenario.py
+++ b/app/routers/epa/dscenario.py
@@ -74,7 +74,6 @@ async def create_dscenario(
         body,
         schema=commons["schema"],
         user=commons["user_id"],
-        db_role=commons["db_role"],
         api_version=commons["api_version"],
     )
 
@@ -130,7 +129,6 @@ async def select_dscenario(
         where_data={"cur_user": commons["user_id"]},
         schema=commons["schema"],
         user=commons["user_id"],
-        db_role=commons["db_role"],
     )
     db_version = await get_db_version(log, commons["db_manager"], schema=commons["schema"])
     return {
@@ -170,7 +168,6 @@ async def delete_dscenario(
         where_data=where_data,
         schema=commons["schema"],
         user=commons["user_id"],
-        db_role=commons["db_role"],
     )
 
     if not status:
@@ -263,7 +260,6 @@ async def insert_dscenario_objects(
             data=obj,
             schema=commons["schema"],
             user=commons["user_id"],
-            db_role=commons["db_role"],
         )
         all_rows.extend(rows)
 
@@ -326,7 +322,6 @@ async def upsert_dscenario_objects(
             where_data=where_data,
             schema=commons["schema"],
             user=commons["user_id"],
-            db_role=commons["db_role"],
         )
         all_rows.extend(rows)
 
@@ -373,7 +368,6 @@ async def get_dscenario_object(
         parameters=(dscenario_id, object_id),
         schema=commons["schema"],
         user=commons["user_id"],
-        db_role=commons["db_role"],
     )
 
     if not rows:
@@ -433,7 +427,6 @@ async def update_dscenario_object(
         where_data=where_data,
         schema=commons["schema"],
         user=commons["user_id"],
-        db_role=commons["db_role"],
     )
 
     if not rows:
@@ -487,7 +480,6 @@ async def upsert_dscenario_object(
         where_data=where_data,
         schema=commons["schema"],
         user=commons["user_id"],
-        db_role=commons["db_role"],
     )
     message_text = "Object inserted" if op == "inserted" else "Object updated"
 
@@ -535,7 +527,6 @@ async def delete_dscenario_object(
         where_data=where_data,
         schema=commons["schema"],
         user=commons["user_id"],
-        db_role=commons["db_role"],
     )
 
     if not status:

--- a/app/routers/om/mapzones/dma.py
+++ b/app/routers/om/mapzones/dma.py
@@ -62,7 +62,6 @@ async def get_macrodmas(
         table_name="macrodma",
         columns=None,
         schema=commons["schema"],
-        user=commons["user_id"],
     )
 
     db_version = await get_db_version(log, commons["db_manager"], schema=commons["schema"])
@@ -299,7 +298,6 @@ async def get_dma_connecs(
         where_clause="dma_id = %s",
         parameters=(dma_id,),
         schema=commons["schema"],
-        user=commons["user_id"],
     )
 
     db_version = await get_db_version(log, commons["db_manager"], schema=commons["schema"])

--- a/app/routers/om/mapzones/dma.py
+++ b/app/routers/om/mapzones/dma.py
@@ -63,7 +63,6 @@ async def get_macrodmas(
         columns=None,
         schema=commons["schema"],
         user=commons["user_id"],
-        db_role=commons["db_role"],
     )
 
     db_version = await get_db_version(log, commons["db_manager"], schema=commons["schema"])
@@ -301,7 +300,6 @@ async def get_dma_connecs(
         parameters=(dma_id,),
         schema=commons["schema"],
         user=commons["user_id"],
-        db_role=commons["db_role"],
     )
 
     db_version = await get_db_version(log, commons["db_manager"], schema=commons["schema"])

--- a/app/routers/om/mapzones/dma.py
+++ b/app/routers/om/mapzones/dma.py
@@ -63,6 +63,7 @@ async def get_macrodmas(
         columns=None,
         schema=commons["schema"],
         user=commons["user_id"],
+        db_role=commons["db_role"],
     )
 
     db_version = await get_db_version(log, commons["db_manager"], schema=commons["schema"])
@@ -300,6 +301,7 @@ async def get_dma_connecs(
         parameters=(dma_id,),
         schema=commons["schema"],
         user=commons["user_id"],
+        db_role=commons["db_role"],
     )
 
     db_version = await get_db_version(log, commons["db_manager"], schema=commons["schema"])

--- a/app/routers/om/mapzones/dqa.py
+++ b/app/routers/om/mapzones/dqa.py
@@ -29,7 +29,6 @@ async def get_macrodqas(commons: CommonsDep):
         table_name="macrodqa",
         columns=None,
         schema=commons["schema"],
-        user=commons["user_id"],
     )
 
     db_version = await get_db_version(log, commons["db_manager"], schema=commons["schema"])
@@ -57,7 +56,6 @@ async def get_dqas(commons: CommonsDep):
         table_name="dqa",
         columns=None,
         schema=commons["schema"],
-        user=commons["user_id"],
     )
 
     db_version = await get_db_version(log, commons["db_manager"], schema=commons["schema"])

--- a/app/routers/om/mapzones/dqa.py
+++ b/app/routers/om/mapzones/dqa.py
@@ -30,6 +30,7 @@ async def get_macrodqas(commons: CommonsDep):
         columns=None,
         schema=commons["schema"],
         user=commons["user_id"],
+        db_role=commons["db_role"],
     )
 
     db_version = await get_db_version(log, commons["db_manager"], schema=commons["schema"])
@@ -58,6 +59,7 @@ async def get_dqas(commons: CommonsDep):
         columns=None,
         schema=commons["schema"],
         user=commons["user_id"],
+        db_role=commons["db_role"],
     )
 
     db_version = await get_db_version(log, commons["db_manager"], schema=commons["schema"])

--- a/app/routers/om/mapzones/dqa.py
+++ b/app/routers/om/mapzones/dqa.py
@@ -30,7 +30,6 @@ async def get_macrodqas(commons: CommonsDep):
         columns=None,
         schema=commons["schema"],
         user=commons["user_id"],
-        db_role=commons["db_role"],
     )
 
     db_version = await get_db_version(log, commons["db_manager"], schema=commons["schema"])
@@ -59,7 +58,6 @@ async def get_dqas(commons: CommonsDep):
         columns=None,
         schema=commons["schema"],
         user=commons["user_id"],
-        db_role=commons["db_role"],
     )
 
     db_version = await get_db_version(log, commons["db_manager"], schema=commons["schema"])

--- a/app/routers/om/mapzones/omunit.py
+++ b/app/routers/om/mapzones/omunit.py
@@ -29,7 +29,6 @@ async def get_omunits(commons: CommonsDep):
         table_name="omunit",
         columns=None,
         schema=commons["schema"],
-        user=commons["user_id"],
     )
 
     db_version = await get_db_version(log, commons["db_manager"], schema=commons["schema"])

--- a/app/routers/om/mapzones/omunit.py
+++ b/app/routers/om/mapzones/omunit.py
@@ -30,7 +30,6 @@ async def get_omunits(commons: CommonsDep):
         columns=None,
         schema=commons["schema"],
         user=commons["user_id"],
-        db_role=commons["db_role"],
     )
 
     db_version = await get_db_version(log, commons["db_manager"], schema=commons["schema"])

--- a/app/routers/om/mapzones/omunit.py
+++ b/app/routers/om/mapzones/omunit.py
@@ -30,6 +30,7 @@ async def get_omunits(commons: CommonsDep):
         columns=None,
         schema=commons["schema"],
         user=commons["user_id"],
+        db_role=commons["db_role"],
     )
 
     db_version = await get_db_version(log, commons["db_manager"], schema=commons["schema"])

--- a/app/routers/om/mapzones/omzone.py
+++ b/app/routers/om/mapzones/omzone.py
@@ -30,6 +30,7 @@ async def get_macroomzones(commons: CommonsDep):
         columns=None,
         schema=commons["schema"],
         user=commons["user_id"],
+        db_role=commons["db_role"],
     )
 
     db_version = await get_db_version(log, commons["db_manager"], schema=commons["schema"])
@@ -58,6 +59,7 @@ async def get_omzones(commons: CommonsDep):
         columns=None,
         schema=commons["schema"],
         user=commons["user_id"],
+        db_role=commons["db_role"],
     )
 
     db_version = await get_db_version(log, commons["db_manager"], schema=commons["schema"])

--- a/app/routers/om/mapzones/omzone.py
+++ b/app/routers/om/mapzones/omzone.py
@@ -30,7 +30,6 @@ async def get_macroomzones(commons: CommonsDep):
         columns=None,
         schema=commons["schema"],
         user=commons["user_id"],
-        db_role=commons["db_role"],
     )
 
     db_version = await get_db_version(log, commons["db_manager"], schema=commons["schema"])
@@ -59,7 +58,6 @@ async def get_omzones(commons: CommonsDep):
         columns=None,
         schema=commons["schema"],
         user=commons["user_id"],
-        db_role=commons["db_role"],
     )
 
     db_version = await get_db_version(log, commons["db_manager"], schema=commons["schema"])

--- a/app/routers/om/mapzones/omzone.py
+++ b/app/routers/om/mapzones/omzone.py
@@ -29,7 +29,6 @@ async def get_macroomzones(commons: CommonsDep):
         table_name="macroomzone",
         columns=None,
         schema=commons["schema"],
-        user=commons["user_id"],
     )
 
     db_version = await get_db_version(log, commons["db_manager"], schema=commons["schema"])
@@ -57,7 +56,6 @@ async def get_omzones(commons: CommonsDep):
         table_name="omzone",
         columns=None,
         schema=commons["schema"],
-        user=commons["user_id"],
     )
 
     db_version = await get_db_version(log, commons["db_manager"], schema=commons["schema"])

--- a/app/routers/om/mapzones/presszone.py
+++ b/app/routers/om/mapzones/presszone.py
@@ -30,6 +30,7 @@ async def get_presszones(commons: CommonsDep):
         columns=None,
         schema=commons["schema"],
         user=commons["user_id"],
+        db_role=commons["db_role"],
     )
 
     db_version = await get_db_version(log, commons["db_manager"], schema=commons["schema"])

--- a/app/routers/om/mapzones/presszone.py
+++ b/app/routers/om/mapzones/presszone.py
@@ -30,7 +30,6 @@ async def get_presszones(commons: CommonsDep):
         columns=None,
         schema=commons["schema"],
         user=commons["user_id"],
-        db_role=commons["db_role"],
     )
 
     db_version = await get_db_version(log, commons["db_manager"], schema=commons["schema"])

--- a/app/routers/om/mapzones/presszone.py
+++ b/app/routers/om/mapzones/presszone.py
@@ -29,7 +29,6 @@ async def get_presszones(commons: CommonsDep):
         table_name="presszone",
         columns=None,
         schema=commons["schema"],
-        user=commons["user_id"],
     )
 
     db_version = await get_db_version(log, commons["db_manager"], schema=commons["schema"])

--- a/app/routers/om/mapzones/sector.py
+++ b/app/routers/om/mapzones/sector.py
@@ -30,6 +30,7 @@ async def get_macrosectors(commons: CommonsDep):
         columns=None,
         schema=commons["schema"],
         user=commons["user_id"],
+        db_role=commons["db_role"],
     )
 
     db_version = await get_db_version(log, commons["db_manager"], schema=commons["schema"])
@@ -58,6 +59,7 @@ async def get_sectors(commons: CommonsDep):
         columns=None,
         schema=commons["schema"],
         user=commons["user_id"],
+        db_role=commons["db_role"],
     )
 
     db_version = await get_db_version(log, commons["db_manager"], schema=commons["schema"])

--- a/app/routers/om/mapzones/sector.py
+++ b/app/routers/om/mapzones/sector.py
@@ -30,7 +30,6 @@ async def get_macrosectors(commons: CommonsDep):
         columns=None,
         schema=commons["schema"],
         user=commons["user_id"],
-        db_role=commons["db_role"],
     )
 
     db_version = await get_db_version(log, commons["db_manager"], schema=commons["schema"])
@@ -59,7 +58,6 @@ async def get_sectors(commons: CommonsDep):
         columns=None,
         schema=commons["schema"],
         user=commons["user_id"],
-        db_role=commons["db_role"],
     )
 
     db_version = await get_db_version(log, commons["db_manager"], schema=commons["schema"])

--- a/app/routers/om/mapzones/sector.py
+++ b/app/routers/om/mapzones/sector.py
@@ -29,7 +29,6 @@ async def get_macrosectors(commons: CommonsDep):
         table_name="macrosector",
         columns=None,
         schema=commons["schema"],
-        user=commons["user_id"],
     )
 
     db_version = await get_db_version(log, commons["db_manager"], schema=commons["schema"])
@@ -57,7 +56,6 @@ async def get_sectors(commons: CommonsDep):
         table_name="sector",
         columns=None,
         schema=commons["schema"],
-        user=commons["user_id"],
     )
 
     db_version = await get_db_version(log, commons["db_manager"], schema=commons["schema"])

--- a/app/routers/om/waterbalance.py
+++ b/app/routers/om/waterbalance.py
@@ -104,6 +104,7 @@ async def get_waterbalance(
         parameters=parameters,
         schema=commons["schema"],
         user=commons["user_id"],
+        db_role=commons["db_role"],
     )
 
     db_version = await get_db_version(log, commons["db_manager"], schema=commons["schema"])

--- a/app/routers/om/waterbalance.py
+++ b/app/routers/om/waterbalance.py
@@ -104,7 +104,6 @@ async def get_waterbalance(
         parameters=parameters,
         schema=commons["schema"],
         user=commons["user_id"],
-        db_role=commons["db_role"],
     )
 
     db_version = await get_db_version(log, commons["db_manager"], schema=commons["schema"])

--- a/app/routers/om/waterbalance.py
+++ b/app/routers/om/waterbalance.py
@@ -103,7 +103,6 @@ async def get_waterbalance(
         sql,
         parameters=parameters,
         schema=commons["schema"],
-        user=commons["user_id"],
     )
 
     db_version = await get_db_version(log, commons["db_manager"], schema=commons["schema"])

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,0 +1,287 @@
+"""
+Copyright © 2026 by BGEO. All rights reserved.
+The program is free software: you can redistribute it and/or modify it under the terms of the GNU
+General Public License as published by the Free Software Foundation, either version 3 of the License,
+or (at your option) any later version.
+"""
+
+import logging
+from datetime import datetime, timezone
+
+from psycopg import sql
+
+from .config import TenantSettings, global_settings
+from .auth_constants import GWAPI_DEFAULT_ROLES
+
+logger = logging.getLogger(__name__)
+
+LOG_SCHEMA = "log"
+LOG_TABLE = "gw_api_logs"
+LOG_DB_TABLE = "gw_api_logs_db"
+GWAPI_SCHEMA = "gwapi"
+GWAPI_USERS_TABLE = "users"
+GWAPI_ROLES_TABLE = "roles"
+GWAPI_USER_ROLES_TABLE = "user_roles"
+
+
+async def ensure_tenant_schemas(db_manager, settings: TenantSettings) -> None:
+    if global_settings.log_db_enabled:
+        await ensure_log_schema(db_manager)
+    if settings.auth_mode == "basic":
+        await ensure_gwapi_schema(db_manager)
+        from . import gwapi_users
+
+        await gwapi_users.maybe_bootstrap_user(db_manager, settings)
+
+
+async def ensure_log_schema(db_manager) -> None:
+    async with db_manager.get_db() as conn:
+        if conn is None:
+            return
+        try:
+            async with conn.cursor() as cursor:
+                await cursor.execute(sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(sql.Identifier(LOG_SCHEMA)))
+                await cursor.execute(
+                    sql.SQL(
+                        """
+                        CREATE TABLE IF NOT EXISTS {}.{} (
+                            ts timestamptz NOT NULL,
+                            id bigserial NOT NULL,
+                            method text NOT NULL,
+                            endpoint text NOT NULL,
+                            status integer NOT NULL,
+                            duration_ms integer,
+                            user_name text,
+                            request_id uuid,
+                            client_ip inet,
+                            query_params jsonb,
+                            body_size integer,
+                            response_size integer,
+                            request_headers jsonb,
+                            request_body text,
+                            response_headers jsonb,
+                            response_body text,
+                            PRIMARY KEY (ts, id)
+                        ) PARTITION BY RANGE (ts)
+                        """
+                    ).format(sql.Identifier(LOG_SCHEMA), sql.Identifier(LOG_TABLE))
+                )
+                await cursor.execute(
+                    sql.SQL("ALTER TABLE {}.{} ADD COLUMN IF NOT EXISTS request_headers jsonb").format(
+                        sql.Identifier(LOG_SCHEMA), sql.Identifier(LOG_TABLE)
+                    )
+                )
+                await cursor.execute(
+                    sql.SQL("ALTER TABLE {}.{} ADD COLUMN IF NOT EXISTS request_body text").format(
+                        sql.Identifier(LOG_SCHEMA), sql.Identifier(LOG_TABLE)
+                    )
+                )
+                await cursor.execute(
+                    sql.SQL("ALTER TABLE {}.{} ADD COLUMN IF NOT EXISTS response_headers jsonb").format(
+                        sql.Identifier(LOG_SCHEMA), sql.Identifier(LOG_TABLE)
+                    )
+                )
+                await cursor.execute(
+                    sql.SQL("ALTER TABLE {}.{} ADD COLUMN IF NOT EXISTS response_body text").format(
+                        sql.Identifier(LOG_SCHEMA), sql.Identifier(LOG_TABLE)
+                    )
+                )
+                await cursor.execute(
+                    sql.SQL("ALTER TABLE {}.{} DROP COLUMN IF EXISTS user_agent").format(
+                        sql.Identifier(LOG_SCHEMA), sql.Identifier(LOG_TABLE)
+                    )
+                )
+                await cursor.execute(
+                    sql.SQL("CREATE INDEX IF NOT EXISTS {} ON {}.{} (ts DESC)").format(
+                        sql.Identifier("gw_api_logs_ts_idx"),
+                        sql.Identifier(LOG_SCHEMA),
+                        sql.Identifier(LOG_TABLE),
+                    )
+                )
+                await cursor.execute(
+                    sql.SQL("CREATE INDEX IF NOT EXISTS {} ON {}.{} (endpoint)").format(
+                        sql.Identifier("gw_api_logs_endpoint_idx"),
+                        sql.Identifier(LOG_SCHEMA),
+                        sql.Identifier(LOG_TABLE),
+                    )
+                )
+                await cursor.execute(
+                    sql.SQL("CREATE INDEX IF NOT EXISTS {} ON {}.{} (method)").format(
+                        sql.Identifier("gw_api_logs_method_idx"),
+                        sql.Identifier(LOG_SCHEMA),
+                        sql.Identifier(LOG_TABLE),
+                    )
+                )
+                await cursor.execute(
+                    sql.SQL("CREATE INDEX IF NOT EXISTS {} ON {}.{} (status)").format(
+                        sql.Identifier("gw_api_logs_status_idx"),
+                        sql.Identifier(LOG_SCHEMA),
+                        sql.Identifier(LOG_TABLE),
+                    )
+                )
+                await cursor.execute(
+                    sql.SQL("CREATE INDEX IF NOT EXISTS {} ON {}.{} (user_name)").format(
+                        sql.Identifier("gw_api_logs_user_idx"),
+                        sql.Identifier(LOG_SCHEMA),
+                        sql.Identifier(LOG_TABLE),
+                    )
+                )
+                await cursor.execute(
+                    sql.SQL("CREATE INDEX IF NOT EXISTS {} ON {}.{} (request_id)").format(
+                        sql.Identifier("gw_api_logs_request_id_idx"),
+                        sql.Identifier(LOG_SCHEMA),
+                        sql.Identifier(LOG_TABLE),
+                    )
+                )
+                await cursor.execute(
+                    sql.SQL(
+                        """
+                        CREATE TABLE IF NOT EXISTS {}.{} (
+                            ts timestamptz NOT NULL,
+                            id bigserial NOT NULL,
+                            request_id uuid,
+                            schema_name text,
+                            function_name text,
+                            sql_text text,
+                            response_json text,
+                            duration_ms integer,
+                            status text,
+                            error text,
+                            PRIMARY KEY (ts, id)
+                        ) PARTITION BY RANGE (ts)
+                        """
+                    ).format(sql.Identifier(LOG_SCHEMA), sql.Identifier(LOG_DB_TABLE))
+                )
+                await cursor.execute(
+                    sql.SQL("CREATE INDEX IF NOT EXISTS {} ON {}.{} (ts DESC)").format(
+                        sql.Identifier("gw_api_logs_db_ts_idx"),
+                        sql.Identifier(LOG_SCHEMA),
+                        sql.Identifier(LOG_DB_TABLE),
+                    )
+                )
+                await cursor.execute(
+                    sql.SQL("CREATE INDEX IF NOT EXISTS {} ON {}.{} (request_id)").format(
+                        sql.Identifier("gw_api_logs_db_request_id_idx"),
+                        sql.Identifier(LOG_SCHEMA),
+                        sql.Identifier(LOG_DB_TABLE),
+                    )
+                )
+            await conn.commit()
+            await ensure_log_partition(conn, datetime.now(timezone.utc), LOG_TABLE)
+            await ensure_log_partition(conn, datetime.now(timezone.utc), LOG_DB_TABLE)
+            await conn.commit()
+        except Exception:
+            await conn.rollback()
+            raise
+
+
+async def ensure_gwapi_schema(db_manager) -> None:
+    async with db_manager.get_db() as conn:
+        if conn is None:
+            return
+        try:
+            async with conn.cursor() as cursor:
+                await cursor.execute(sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(sql.Identifier(GWAPI_SCHEMA)))
+                await cursor.execute(
+                    sql.SQL(
+                        """
+                        CREATE TABLE IF NOT EXISTS {}.{} (
+                            name text PRIMARY KEY,
+                            description text
+                        )
+                        """
+                    ).format(sql.Identifier(GWAPI_SCHEMA), sql.Identifier(GWAPI_ROLES_TABLE))
+                )
+                for role_name, description in GWAPI_DEFAULT_ROLES:
+                    await cursor.execute(
+                        sql.SQL(
+                            """
+                            INSERT INTO {}.{} (name, description)
+                            VALUES (%s, %s)
+                            ON CONFLICT (name) DO NOTHING
+                            """
+                        ).format(sql.Identifier(GWAPI_SCHEMA), sql.Identifier(GWAPI_ROLES_TABLE)),
+                        (role_name, description),
+                    )
+                await cursor.execute(
+                    sql.SQL(
+                        """
+                        CREATE TABLE IF NOT EXISTS {}.{} (
+                            id bigserial PRIMARY KEY,
+                            username text NOT NULL UNIQUE,
+                            password_hash text NOT NULL,
+                            db_role text NOT NULL,
+                            enabled boolean NOT NULL DEFAULT true,
+                            created_at timestamptz NOT NULL DEFAULT now(),
+                            updated_at timestamptz NOT NULL DEFAULT now()
+                        )
+                        """
+                    ).format(sql.Identifier(GWAPI_SCHEMA), sql.Identifier(GWAPI_USERS_TABLE))
+                )
+                await cursor.execute(
+                    sql.SQL("CREATE INDEX IF NOT EXISTS {} ON {}.{} (username)").format(
+                        sql.Identifier("gwapi_users_username_idx"),
+                        sql.Identifier(GWAPI_SCHEMA),
+                        sql.Identifier(GWAPI_USERS_TABLE),
+                    )
+                )
+                await cursor.execute(
+                    sql.SQL(
+                        """
+                        CREATE TABLE IF NOT EXISTS {}.{} (
+                            user_id bigint NOT NULL REFERENCES {}.{} (id) ON DELETE CASCADE,
+                            role_name text NOT NULL REFERENCES {}.{} (name) ON DELETE CASCADE,
+                            PRIMARY KEY (user_id, role_name)
+                        )
+                        """
+                    ).format(
+                        sql.Identifier(GWAPI_SCHEMA),
+                        sql.Identifier(GWAPI_USER_ROLES_TABLE),
+                        sql.Identifier(GWAPI_SCHEMA),
+                        sql.Identifier(GWAPI_USERS_TABLE),
+                        sql.Identifier(GWAPI_SCHEMA),
+                        sql.Identifier(GWAPI_ROLES_TABLE),
+                    )
+                )
+                await cursor.execute(
+                    sql.SQL("CREATE INDEX IF NOT EXISTS {} ON {}.{} (user_id)").format(
+                        sql.Identifier("gwapi_user_roles_user_id_idx"),
+                        sql.Identifier(GWAPI_SCHEMA),
+                        sql.Identifier(GWAPI_USER_ROLES_TABLE),
+                    )
+                )
+            await conn.commit()
+        except Exception:
+            await conn.rollback()
+            raise
+
+
+def _month_range(ts: datetime, table_name: str) -> tuple[datetime, datetime, str]:
+    month_start = datetime(ts.year, ts.month, 1, tzinfo=ts.tzinfo)
+    if ts.month == 12:
+        month_end = datetime(ts.year + 1, 1, 1, tzinfo=ts.tzinfo)
+    else:
+        month_end = datetime(ts.year, ts.month + 1, 1, tzinfo=ts.tzinfo)
+    partition_name = f"{table_name}_{month_start.year}_{month_start.month:02d}"
+    return month_start, month_end, partition_name
+
+
+async def ensure_log_partition(conn, ts: datetime, table_name: str) -> None:
+    month_start, month_end, partition_name = _month_range(ts, table_name)
+    async with conn.cursor() as cursor:
+        await cursor.execute(
+            sql.SQL(
+                """
+                CREATE TABLE IF NOT EXISTS {}.{}
+                PARTITION OF {}.{}
+                FOR VALUES FROM ({}) TO ({})
+                """
+            ).format(
+                sql.Identifier(LOG_SCHEMA),
+                sql.Identifier(partition_name),
+                sql.Identifier(LOG_SCHEMA),
+                sql.Identifier(table_name),
+                sql.Literal(month_start),
+                sql.Literal(month_end),
+            ),
+        )

--- a/app/tenant.py
+++ b/app/tenant.py
@@ -112,6 +112,10 @@ def serialize_tenant_settings(settings: TenantSettings) -> str:
         ("DB_POOL_MAX_WAITING", settings.db_pool_max_waiting),
         ("DB_POOL_MAX_IDLE", settings.db_pool_max_idle),
         ("DB_CONNECT_TIMEOUT", settings.db_connect_timeout),
+        ("AUTH_MODE", settings.auth_mode),
+        ("AUTH_BASIC_BOOTSTRAP_USER", settings.auth_basic_bootstrap_user),
+        ("AUTH_BASIC_BOOTSTRAP_PASSWORD", settings.auth_basic_bootstrap_password),
+        # DEPRECATED #22: stop writing KEYCLOAK_ENABLED on admin serialize; remove in 2.0.0
         ("KEYCLOAK_ENABLED", settings.keycloak_enabled),
         ("KEYCLOAK_URL", settings.keycloak_url),
         ("KEYCLOAK_REALM", settings.keycloak_realm),
@@ -188,13 +192,16 @@ class TenantRegistry:
             await asyncio.wait_for(db.init_conn_pool(), timeout=max(settings.db_connect_timeout, 5.0))
         except Exception as exc:
             logger.warning("[%s] pool init failed; tenant kept, will retry on demand: %s", tid, exc)
-        if global_settings.log_db_enabled and db.connection_pool is not None:
+        if db.connection_pool is not None:
             try:
-                from .utils.utils import ensure_log_schema
+                from .schemas import ensure_tenant_schemas
 
-                await asyncio.wait_for(ensure_log_schema(db), timeout=max(settings.db_connect_timeout, 5.0))
+                await asyncio.wait_for(
+                    ensure_tenant_schemas(db, settings),
+                    timeout=max(settings.db_connect_timeout, 5.0),
+                )
             except Exception as exc:
-                logger.warning("[%s] log schema init failed: %s", tid, exc)
+                logger.warning("[%s] tenant schema init failed: %s", tid, exc)
         idp = build_idp(settings)
         api_logger, api_log_date = _build_tenant_logger(tid)
         return Tenant(

--- a/app/utils/utils.py
+++ b/app/utils/utils.py
@@ -16,6 +16,7 @@ import uuid
 from collections import defaultdict, deque
 from logging.handlers import TimedRotatingFileHandler
 
+from dataclasses import dataclass
 from typing import Any, Awaitable, Callable, Dict, Literal
 from datetime import date, datetime, timezone
 from fastapi import FastAPI, HTTPException, Request
@@ -34,10 +35,34 @@ logger = logging.getLogger(__name__)
 REQUEST_ID_CTX: contextvars.ContextVar[uuid.UUID | None] = contextvars.ContextVar("request_id", default=None)
 
 
+@dataclass(frozen=True)
+class DbIdentity:
+    """Request-scoped DB user for SET ROLE (set by common_parameters)."""
+
+    username: str | None
+    db_role: str | None
+
+
+DB_IDENTITY_CTX: contextvars.ContextVar[DbIdentity | None] = contextvars.ContextVar("db_identity", default=None)
+
+
 def _db_identity(user: str | None, db_role: str | None = None) -> str | None:
     if user == "anonymous" or user is None:
         return None
     return db_role if db_role is not None else user
+
+
+def _resolve_db_identity(user: str | None = "anonymous", db_role: str | None = None) -> str | None:
+    """Merge explicit args with DB_IDENTITY_CTX; used by execute_* for SET ROLE."""
+    ctx = DB_IDENTITY_CTX.get()
+    if ctx is not None:
+        if user is None or user == "anonymous":
+            user = ctx.username if ctx.username is not None else "anonymous"
+            if db_role is None:
+                db_role = ctx.db_role
+        elif db_role is None and user == ctx.username:
+            db_role = ctx.db_role
+    return _db_identity(user, db_role)
 
 
 _rate_limit_state: dict[tuple[str, str], deque[float]] = defaultdict(deque)
@@ -289,7 +314,7 @@ async def execute_procedure(  # noqa: C901
         )
         result = dict()
         log.debug("execute_procedure SQL: %s", sql_preview)
-        identity = _db_identity(user, db_role)
+        identity = _resolve_db_identity(user, db_role)
         db_error = None
         try:
             async with conn.cursor() as cursor:
@@ -405,7 +430,7 @@ async def execute_sql_select(
             raise DatabaseUnavailableError()
         try:
             async with conn.cursor(row_factory=dict_row) as cursor:
-                identity = _db_identity(user, db_role)
+                identity = _resolve_db_identity(user, db_role)
                 if set_role and identity:
                     await cursor.execute(sql.SQL("SET ROLE {}").format(sql.Identifier(identity)))
                 if parameters is None:
@@ -456,7 +481,7 @@ async def execute_sql(
             raise DatabaseUnavailableError()
         try:
             async with conn.cursor(row_factory=dict_row) as cursor:
-                identity = _db_identity(user, db_role)
+                identity = _resolve_db_identity(user, db_role)
                 if set_role and identity:
                     await cursor.execute(sql.SQL("SET ROLE {}").format(sql.Identifier(identity)))
                 if parameters is None:
@@ -514,7 +539,7 @@ async def execute_sql_insert(
             raise DatabaseUnavailableError()
         try:
             async with conn.cursor(row_factory=dict_row) as cursor:
-                identity = _db_identity(user, db_role)
+                identity = _resolve_db_identity(user, db_role)
                 if set_role and identity:
                     await cursor.execute(sql.SQL("SET ROLE {}").format(sql.Identifier(identity)))
                 await cursor.execute(query, tuple(values))
@@ -573,7 +598,7 @@ async def execute_sql_update(
             raise DatabaseUnavailableError()
         try:
             async with conn.cursor(row_factory=dict_row) as cursor:
-                identity = _db_identity(user, db_role)
+                identity = _resolve_db_identity(user, db_role)
                 if set_role and identity:
                     await cursor.execute(sql.SQL("SET ROLE {}").format(sql.Identifier(identity)))
                 await cursor.execute(query, tuple(values))
@@ -700,7 +725,7 @@ async def execute_sql_delete(
                 if not rows:
                     return False
 
-                identity = _db_identity(user, db_role)
+                identity = _resolve_db_identity(user, db_role)
                 if set_role and identity:
                     await cursor.execute(sql.SQL("SET ROLE {}").format(sql.Identifier(identity)))
                 await cursor.execute(query, tuple(values))

--- a/app/utils/utils.py
+++ b/app/utils/utils.py
@@ -27,8 +27,18 @@ from psycopg.types.json import Json
 from ..models.util_models import APIResponse
 from ..exceptions import DatabaseUnavailableError, ProcedureError
 from ..config import global_settings
+from ..schemas import LOG_DB_TABLE, LOG_SCHEMA, LOG_TABLE, ensure_log_partition
 
 logger = logging.getLogger(__name__)
+
+REQUEST_ID_CTX: contextvars.ContextVar[uuid.UUID | None] = contextvars.ContextVar("request_id", default=None)
+
+
+def _db_identity(user: str | None, db_role: str | None = None) -> str | None:
+    if user == "anonymous" or user is None:
+        return None
+    return db_role if db_role is not None else user
+
 
 _rate_limit_state: dict[tuple[str, str], deque[float]] = defaultdict(deque)
 _rate_limit_lock = asyncio.Lock()
@@ -220,6 +230,7 @@ async def execute_procedure(  # noqa: C901
     needs_write=False,
     schema=None,
     user: str | None = "anonymous",
+    db_role: str | None = None,
     api_version=None,
 ):
     """
@@ -278,10 +289,7 @@ async def execute_procedure(  # noqa: C901
         )
         result = dict()
         log.debug("execute_procedure SQL: %s", sql_preview)
-        if user == "anonymous":
-            identity = None
-        else:
-            identity = user
+        identity = _db_identity(user, db_role)
         db_error = None
         try:
             async with conn.cursor() as cursor:
@@ -368,6 +376,7 @@ async def execute_sql_select(
     set_role: bool = True,
     schema: str | None = None,
     user: str | None = "anonymous",
+    db_role: str | None = None,
 ):
     """
     Execute a SELECT query on a table and return rows as dicts.
@@ -396,7 +405,7 @@ async def execute_sql_select(
             raise DatabaseUnavailableError()
         try:
             async with conn.cursor(row_factory=dict_row) as cursor:
-                identity = None if user == "anonymous" else user
+                identity = _db_identity(user, db_role)
                 if set_role and identity:
                     await cursor.execute(sql.SQL("SET ROLE {}").format(sql.Identifier(identity)))
                 if parameters is None:
@@ -420,6 +429,7 @@ async def execute_sql(
     set_role: bool = True,
     schema: str | None = None,
     user: str | None = "anonymous",
+    db_role: str | None = None,
 ):
     """
     Execute a raw SQL query and return rows as dicts.
@@ -446,7 +456,7 @@ async def execute_sql(
             raise DatabaseUnavailableError()
         try:
             async with conn.cursor(row_factory=dict_row) as cursor:
-                identity = None if user == "anonymous" else user
+                identity = _db_identity(user, db_role)
                 if set_role and identity:
                     await cursor.execute(sql.SQL("SET ROLE {}").format(sql.Identifier(identity)))
                 if parameters is None:
@@ -470,6 +480,7 @@ async def execute_sql_insert(
     set_role: bool = True,
     schema: str | None = None,
     user: str | None = "anonymous",
+    db_role: str | None = None,
 ):
     """
     Execute an INSERT on a table and return inserted rows as dicts.
@@ -503,7 +514,7 @@ async def execute_sql_insert(
             raise DatabaseUnavailableError()
         try:
             async with conn.cursor(row_factory=dict_row) as cursor:
-                identity = None if user == "anonymous" else user
+                identity = _db_identity(user, db_role)
                 if set_role and identity:
                     await cursor.execute(sql.SQL("SET ROLE {}").format(sql.Identifier(identity)))
                 await cursor.execute(query, tuple(values))
@@ -525,6 +536,7 @@ async def execute_sql_update(
     set_role: bool = True,
     schema: str | None = None,
     user: str | None = "anonymous",
+    db_role: str | None = None,
 ):
     """
     Execute an UPDATE on a table and return updated rows as dicts.
@@ -561,7 +573,7 @@ async def execute_sql_update(
             raise DatabaseUnavailableError()
         try:
             async with conn.cursor(row_factory=dict_row) as cursor:
-                identity = None if user == "anonymous" else user
+                identity = _db_identity(user, db_role)
                 if set_role and identity:
                     await cursor.execute(sql.SQL("SET ROLE {}").format(sql.Identifier(identity)))
                 await cursor.execute(query, tuple(values))
@@ -583,6 +595,7 @@ async def execute_sql_upsert(
     set_role: bool = True,
     schema: str | None = None,
     user: str | None = "anonymous",
+    db_role: str | None = None,
 ) -> tuple[list[dict], Literal["inserted", "updated"]]:
     """
     Try UPDATE first; if no row matched, INSERT with where_data + data.
@@ -599,6 +612,7 @@ async def execute_sql_upsert(
             set_role=set_role,
             schema=schema,
             user=user,
+            db_role=db_role,
         )
         if rows:
             return rows, "updated"
@@ -613,6 +627,7 @@ async def execute_sql_upsert(
             set_role=set_role,
             schema=schema,
             user=user,
+            db_role=db_role,
         )
         if rows:
             return rows, "updated"
@@ -626,6 +641,7 @@ async def execute_sql_upsert(
         set_role=set_role,
         schema=schema,
         user=user,
+        db_role=db_role,
     )
     return rows, "inserted"
 
@@ -638,6 +654,7 @@ async def execute_sql_delete(
     set_role: bool = True,
     schema: str | None = None,
     user: str | None = "anonymous",
+    db_role: str | None = None,
 ) -> bool:
     """
     Execute a DELETE on a table and return True if successful, False otherwise.
@@ -678,11 +695,12 @@ async def execute_sql_delete(
                     parameters=tuple(values),
                     schema=schema_name,
                     user=user,
+                    db_role=db_role,
                 )
                 if not rows:
                     return False
 
-                identity = None if user == "anonymous" else user
+                identity = _db_identity(user, db_role)
                 if set_role and identity:
                     await cursor.execute(sql.SQL("SET ROLE {}").format(sql.Identifier(identity)))
                 await cursor.execute(query, tuple(values))
@@ -789,184 +807,6 @@ def remove_handlers(log=None):
         log = logging.getLogger()
     for hdlr in log.handlers[:]:
         log.removeHandler(hdlr)
-
-
-LOG_SCHEMA = "log"
-LOG_TABLE = "gw_api_logs"
-LOG_DB_TABLE = "gw_api_logs_db"
-REQUEST_ID_CTX: contextvars.ContextVar[uuid.UUID | None] = contextvars.ContextVar("request_id", default=None)
-
-
-async def ensure_log_schema(db_manager) -> None:
-    async with db_manager.get_db() as conn:
-        if conn is None:
-            return
-        try:
-            async with conn.cursor() as cursor:
-                await cursor.execute(sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(sql.Identifier(LOG_SCHEMA)))
-                await cursor.execute(
-                    sql.SQL(
-                        """
-                        CREATE TABLE IF NOT EXISTS {}.{} (
-                            ts timestamptz NOT NULL,
-                            id bigserial NOT NULL,
-                            method text NOT NULL,
-                            endpoint text NOT NULL,
-                            status integer NOT NULL,
-                            duration_ms integer,
-                            user_name text,
-                            request_id uuid,
-                            client_ip inet,
-                            query_params jsonb,
-                            body_size integer,
-                            response_size integer,
-                            request_headers jsonb,
-                            request_body text,
-                            response_headers jsonb,
-                            response_body text,
-                            PRIMARY KEY (ts, id)
-                        ) PARTITION BY RANGE (ts)
-                        """
-                    ).format(sql.Identifier(LOG_SCHEMA), sql.Identifier(LOG_TABLE))
-                )
-                await cursor.execute(
-                    sql.SQL("ALTER TABLE {}.{} ADD COLUMN IF NOT EXISTS request_headers jsonb").format(
-                        sql.Identifier(LOG_SCHEMA), sql.Identifier(LOG_TABLE)
-                    )
-                )
-                await cursor.execute(
-                    sql.SQL("ALTER TABLE {}.{} ADD COLUMN IF NOT EXISTS request_body text").format(
-                        sql.Identifier(LOG_SCHEMA), sql.Identifier(LOG_TABLE)
-                    )
-                )
-                await cursor.execute(
-                    sql.SQL("ALTER TABLE {}.{} ADD COLUMN IF NOT EXISTS response_headers jsonb").format(
-                        sql.Identifier(LOG_SCHEMA), sql.Identifier(LOG_TABLE)
-                    )
-                )
-                await cursor.execute(
-                    sql.SQL("ALTER TABLE {}.{} ADD COLUMN IF NOT EXISTS response_body text").format(
-                        sql.Identifier(LOG_SCHEMA), sql.Identifier(LOG_TABLE)
-                    )
-                )
-                await cursor.execute(
-                    sql.SQL("ALTER TABLE {}.{} DROP COLUMN IF EXISTS user_agent").format(
-                        sql.Identifier(LOG_SCHEMA), sql.Identifier(LOG_TABLE)
-                    )
-                )
-                await cursor.execute(
-                    sql.SQL("CREATE INDEX IF NOT EXISTS {} ON {}.{} (ts DESC)").format(
-                        sql.Identifier("gw_api_logs_ts_idx"),
-                        sql.Identifier(LOG_SCHEMA),
-                        sql.Identifier(LOG_TABLE),
-                    )
-                )
-                await cursor.execute(
-                    sql.SQL("CREATE INDEX IF NOT EXISTS {} ON {}.{} (endpoint)").format(
-                        sql.Identifier("gw_api_logs_endpoint_idx"),
-                        sql.Identifier(LOG_SCHEMA),
-                        sql.Identifier(LOG_TABLE),
-                    )
-                )
-                await cursor.execute(
-                    sql.SQL("CREATE INDEX IF NOT EXISTS {} ON {}.{} (method)").format(
-                        sql.Identifier("gw_api_logs_method_idx"),
-                        sql.Identifier(LOG_SCHEMA),
-                        sql.Identifier(LOG_TABLE),
-                    )
-                )
-                await cursor.execute(
-                    sql.SQL("CREATE INDEX IF NOT EXISTS {} ON {}.{} (status)").format(
-                        sql.Identifier("gw_api_logs_status_idx"),
-                        sql.Identifier(LOG_SCHEMA),
-                        sql.Identifier(LOG_TABLE),
-                    )
-                )
-                await cursor.execute(
-                    sql.SQL("CREATE INDEX IF NOT EXISTS {} ON {}.{} (user_name)").format(
-                        sql.Identifier("gw_api_logs_user_idx"),
-                        sql.Identifier(LOG_SCHEMA),
-                        sql.Identifier(LOG_TABLE),
-                    )
-                )
-                await cursor.execute(
-                    sql.SQL("CREATE INDEX IF NOT EXISTS {} ON {}.{} (request_id)").format(
-                        sql.Identifier("gw_api_logs_request_id_idx"),
-                        sql.Identifier(LOG_SCHEMA),
-                        sql.Identifier(LOG_TABLE),
-                    )
-                )
-                await cursor.execute(
-                    sql.SQL(
-                        """
-                        CREATE TABLE IF NOT EXISTS {}.{} (
-                            ts timestamptz NOT NULL,
-                            id bigserial NOT NULL,
-                            request_id uuid,
-                            schema_name text,
-                            function_name text,
-                            sql_text text,
-                            response_json text,
-                            duration_ms integer,
-                            status text,
-                            error text,
-                            PRIMARY KEY (ts, id)
-                        ) PARTITION BY RANGE (ts)
-                        """
-                    ).format(sql.Identifier(LOG_SCHEMA), sql.Identifier(LOG_DB_TABLE))
-                )
-                await cursor.execute(
-                    sql.SQL("CREATE INDEX IF NOT EXISTS {} ON {}.{} (ts DESC)").format(
-                        sql.Identifier("gw_api_logs_db_ts_idx"),
-                        sql.Identifier(LOG_SCHEMA),
-                        sql.Identifier(LOG_DB_TABLE),
-                    )
-                )
-                await cursor.execute(
-                    sql.SQL("CREATE INDEX IF NOT EXISTS {} ON {}.{} (request_id)").format(
-                        sql.Identifier("gw_api_logs_db_request_id_idx"),
-                        sql.Identifier(LOG_SCHEMA),
-                        sql.Identifier(LOG_DB_TABLE),
-                    )
-                )
-            await conn.commit()
-            await ensure_log_partition(conn, datetime.now(timezone.utc), LOG_TABLE)
-            await ensure_log_partition(conn, datetime.now(timezone.utc), LOG_DB_TABLE)
-            await conn.commit()
-        except Exception:
-            await conn.rollback()
-            raise
-
-
-def _month_range(ts: datetime, table_name: str) -> tuple[datetime, datetime, str]:
-    month_start = datetime(ts.year, ts.month, 1, tzinfo=ts.tzinfo)
-    if ts.month == 12:
-        month_end = datetime(ts.year + 1, 1, 1, tzinfo=ts.tzinfo)
-    else:
-        month_end = datetime(ts.year, ts.month + 1, 1, tzinfo=ts.tzinfo)
-    partition_name = f"{table_name}_{month_start.year}_{month_start.month:02d}"
-    return month_start, month_end, partition_name
-
-
-async def ensure_log_partition(conn, ts: datetime, table_name: str) -> None:
-    month_start, month_end, partition_name = _month_range(ts, table_name)
-    async with conn.cursor() as cursor:
-        await cursor.execute(
-            sql.SQL(
-                """
-                CREATE TABLE IF NOT EXISTS {}.{}
-                PARTITION OF {}.{}
-                FOR VALUES FROM ({}) TO ({})
-                """
-            ).format(
-                sql.Identifier(LOG_SCHEMA),
-                sql.Identifier(partition_name),
-                sql.Identifier(LOG_SCHEMA),
-                sql.Identifier(table_name),
-                sql.Literal(month_start),
-                sql.Literal(month_end),
-            ),
-        )
 
 
 async def insert_api_log(db_manager, record: Dict[str, Any]) -> None:

--- a/config/tenants/example.env
+++ b/config/tenants/example.env
@@ -38,8 +38,14 @@ DB_POOL_MAX_WAITING=0
 DB_POOL_MAX_IDLE=300
 DB_CONNECT_TIMEOUT=5
 
-# Keycloak (per tenant). Disable to allow anonymous access.
-KEYCLOAK_ENABLED=false
+# Auth mode (per tenant). `none`, `basic` or `keycloak`
+AUTH_MODE=none
+# When `AUTH_MODE=basic`, optional first user if gwapi.users is empty.
+# AUTH_BASIC_BOOTSTRAP_USER=user
+# AUTH_BASIC_BOOTSTRAP_PASSWORD=changeme
+
+# Keycloak configuration (per tenant)
+# KEYCLOAK_ENABLED=false  # DEPRECATED #22: use AUTH_MODE=keycloak instead of KEYCLOAK_ENABLED=true
 KEYCLOAK_URL=
 KEYCLOAK_REALM=
 KEYCLOAK_CLIENT_ID=

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -15,7 +15,7 @@ From any directory on the server:
 curl -fsSL https://raw.githubusercontent.com/Giswater/giswater-api/main/deploy/install.sh | sudo bash
 ```
 
-Pin a release:
+Pin deploy templates to a release (`docker-compose.yml`, entrypoint, env examples — separate from the Docker image tag prompt):
 
 ```bash
 GISWATER_API_REF=v1.3.2 curl -fsSL https://raw.githubusercontent.com/Giswater/giswater-api/main/deploy/install.sh | sudo bash
@@ -34,12 +34,19 @@ sudo GISWATER_API_REF=v1.3.2 ./install.sh
 | Prompt | Purpose |
 |--------|---------|
 | Public URL / IP | Printed endpoints; default Keycloak callback |
-| Docker image tag | `GISWATER_API_TAG` (default `latest`) |
+| Docker image tag | `GISWATER_API_TAG` — which image to pull from Docker Hub (default `latest`) |
 | Admin password | HTTP Basic for `${API_ROOT}/admin/*` |
 | DB connection | Host, port, name, user, password, schema |
 | Keycloak (optional) | Per-tenant auth for `${API_ROOT}/v1/*` |
 
 When Postgres runs on the same host as Docker, use **`host.docker.internal`** as DB host (default).
+
+**Existing install with `Permission denied` on `main.env`?** The tenant file must be readable by the container user:
+
+```bash
+sudo chmod 644 /opt/giswater-api/config/tenants/main.env
+cd /opt/giswater-api && docker compose restart app
+```
 
 ## Manual setup
 
@@ -50,6 +57,9 @@ cd /opt/giswater-api
 #       deploy/.env.prod.example → .env,
 #       deploy/main.env.example → config/tenants/main.env
 # edit secrets, then:
+chmod 600 .env
+chmod 755 config config/tenants
+chmod 644 config/tenants/*.env
 docker compose pull && docker compose up -d
 ```
 

--- a/deploy/docker-entrypoint.sh
+++ b/deploy/docker-entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
-# Production entrypoint: named Docker volumes mount as root-owned; ensure /app/logs
-# is writable by the app user before dropping privileges.
+# Production entrypoint: fix log volume ownership, then drop to the app user.
+# Tenant config under /app/config is bind-mounted read-only from the host;
+# install.sh sets config/tenants/*.env to mode 644 so the app user can read them.
 set -e
 
 mkdir -p /app/logs

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -8,14 +8,14 @@
 #   wget -O install.sh https://raw.githubusercontent.com/Giswater/giswater-api/main/deploy/install.sh
 #   chmod +x install.sh && sudo ./install.sh
 #
-# Pin a release:
+# Pin deploy templates to a release (docker-compose.yml, entrypoint, env examples):
 #   GISWATER_API_REF=v1.3.2 curl -fsSL .../deploy/install.sh | sudo bash
 #
 # Environment overrides (optional):
 #   GISWATER_API_INSTALL_DIR   default /opt/giswater-api
 #   GISWATER_API_REF           git ref for deploy assets (default main)
 #   GISWATER_API_IMAGE         Docker image (default bgeoopengis/giswater-api)
-#   GISWATER_API_TAG           Docker tag (default latest; prompted interactively)
+#   GISWATER_API_TAG           default for the image-tag prompt (default latest)
 
 set -euo pipefail
 
@@ -138,6 +138,16 @@ normalize_public_url() {
   printf '%s' "$url"
 }
 
+# .env is read by Docker Compose on the host (600). Tenant env files are read
+# inside the container by the non-root app user, so they must be world-readable
+# (config is bind-mounted read-only — the entrypoint cannot fix this).
+fix_permissions() {
+  local dir="$1"
+  chmod 600 "${dir}/.env"
+  chmod 755 "${dir}/config" "${dir}/config/tenants"
+  chmod 644 "${dir}/config/tenants/"*.env 2>/dev/null || true
+}
+
 main() {
   require_root
   require_commands
@@ -224,7 +234,6 @@ main() {
   download_file "main.env.example" "${INSTALL_DIR}/config/tenants/${TENANT_ID}.env"
 
   chmod 755 "${INSTALL_DIR}/docker-entrypoint.sh"
-  chmod 600 "${INSTALL_DIR}/.env" "${INSTALL_DIR}/config/tenants/${TENANT_ID}.env"
 
   # --- .env ---
   set_env_value "${INSTALL_DIR}/.env" "GISWATER_API_IMAGE" "$DEFAULT_IMAGE"
@@ -247,6 +256,8 @@ main() {
   set_env_value "$tenant_file" "KEYCLOAK_CLIENT_ID" "$keycloak_client_id"
   set_env_value "$tenant_file" "KEYCLOAK_CLIENT_SECRET" "$keycloak_client_secret"
   set_env_value "$tenant_file" "KEYCLOAK_CALLBACK_URI" "$keycloak_callback"
+
+  fix_permissions "$INSTALL_DIR"
 
   if [[ "$START_NOW" == "true" ]]; then
     info "Starting containers"
@@ -281,7 +292,7 @@ main() {
   echo "    docker compose pull && docker compose up -d   # upgrade"
   echo
   echo "  Reverse proxy: see deploy/nginx.conf.example in the repo."
-  echo "  Pin version:   GISWATER_API_REF=v1.3.2 bash install.sh"
+  echo "  Pin deploy templates: GISWATER_API_REF=v1.3.2 curl -fsSL .../deploy/install.sh | sudo bash"
   echo
 }
 

--- a/deploy/main.env.example
+++ b/deploy/main.env.example
@@ -27,7 +27,9 @@ DB_POOL_MAX_WAITING=0
 DB_POOL_MAX_IDLE=300
 DB_CONNECT_TIMEOUT=5
 
-# Keycloak (per tenant). Disable for anonymous access.
+# Keycloak (per tenant). Prefer AUTH_MODE=keycloak|basic|none
+AUTH_MODE=none
+# DEPRECATED #22: use AUTH_MODE=keycloak instead
 KEYCLOAK_ENABLED=false
 KEYCLOAK_URL=
 KEYCLOAK_REALM=

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -159,13 +159,21 @@ One file per tenant: `config/tenants/<tenant_id>.env`. The filename stem is the 
 | `DB_POOL_MAX_IDLE` | `300` | Seconds before idle connections may be dropped. |
 | `DB_CONNECT_TIMEOUT` | `5` | Seconds for initial pool open / connectivity checks. |
 
-### Keycloak (tenant API)
-
-When **`KEYCLOAK_ENABLED=true`**, tenant routes expect a valid Bearer JWT for that realm. When `false`, anonymous access is allowed for that tenant (still subject to feature toggles).
+### Tenant API authentication
 
 | Variable | Default | Description |
 | -------- | ------- | ----------- |
-| `KEYCLOAK_ENABLED` | `false` | Enable JWT enforcement for this tenant’s `${API_ROOT}/v1/*`. |
+| `AUTH_MODE` | `none` | `none`, `basic`, or `keycloak`. Primary auth mode for `${API_ROOT}/v1/*`. |
+| `AUTH_BASIC_BOOTSTRAP_USER` | _(empty)_ | When `AUTH_MODE=basic`, optional first user if `gwapi.users` is empty. |
+| `AUTH_BASIC_BOOTSTRAP_PASSWORD` | _(empty)_ | Password for bootstrap user. |
+
+### Keycloak (tenant API)
+
+When **`AUTH_MODE=keycloak`**, tenant routes expect a valid Bearer JWT for that realm. When `none`, anonymous access is allowed for that tenant (still subject to feature toggles).
+
+| Variable | Default | Description |
+| -------- | ------- | ----------- |
+| `KEYCLOAK_ENABLED` | `false` | **Deprecated** (2.0.0). Shim: `true` → `AUTH_MODE=keycloak`. Prefer `AUTH_MODE`. |
 | `KEYCLOAK_URL` | _(required if enabled)_ | Keycloak base URL. |
 | `KEYCLOAK_REALM` | _(required if enabled)_ | Realm. |
 | `KEYCLOAK_CLIENT_ID` | _(required if enabled)_ | Client id. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "pyproj==3.7.2",
     "pyjwt[crypto]==2.12.1",
     "cryptography==46.0.7",
+    "bcrypt==4.3.0",
     "fastapi-keycloak==1.1.1",
     "python-dotenv==1.2.2",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,7 +52,7 @@ def _materialize_tenants_dir() -> str:
         f'DATABASE_URL="{db_url}"\n'
         "DB_POOL_MIN_SIZE=1\nDB_POOL_MAX_SIZE=5\nDB_POOL_TIMEOUT=10\n"
         "DB_POOL_MAX_WAITING=0\nDB_POOL_MAX_IDLE=60\nDB_CONNECT_TIMEOUT=5\n"
-        "KEYCLOAK_ENABLED=false\n"
+        "AUTH_MODE=none\n"
     )
     return str(tmp)
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,61 @@
+"""
+Copyright © 2026 by BGEO. All rights reserved.
+The program is free software: you can redistribute it and/or modify it under the terms of the GNU
+General Public License as published by the Free Software Foundation, either version 3 of the License,
+or (at your option) any later version.
+"""
+
+# Backward-compat tests for KEYCLOAK_ENABLED → AUTH_MODE shim.
+# DEPRECATED #22: delete the legacy tests below when releasing 2.0.0 (grep DEPRECATED #22).
+
+import warnings
+
+
+from app.config import _build_tenant, _resolve_auth_mode
+from app.models.auth_models import ApiUser
+
+
+def test_resolve_auth_mode_explicit_none():
+    assert _resolve_auth_mode({"AUTH_MODE": "none"}) == "none"
+
+
+def test_resolve_auth_mode_explicit_basic():
+    assert _resolve_auth_mode({"AUTH_MODE": "basic"}) == "basic"
+
+
+# DEPRECATED #22: remove in 2.0.0
+def test_resolve_auth_mode_keycloak_enabled_legacy():
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        assert _resolve_auth_mode({"KEYCLOAK_ENABLED": "true"}) == "keycloak"
+    assert any(issubclass(w.category, DeprecationWarning) for w in caught)
+
+
+def test_resolve_auth_mode_default_none():
+    assert _resolve_auth_mode({}) == "none"
+
+
+# DEPRECATED #22: remove in 2.0.0
+def test_build_tenant_auth_mode_from_keycloak_enabled():
+    settings = _build_tenant({"KEYCLOAK_ENABLED": "true", "KEYCLOAK_URL": "https://auth.example.com"})
+    assert settings.auth_mode == "keycloak"
+    assert settings.keycloak_enabled is True
+
+
+def test_api_user_roles():
+    user = ApiUser(
+        sub="1",
+        preferred_username="alice",
+        auth_method="basic",
+        roles=frozenset({"role_basic", "role_edit"}),
+        db_role="postgres",
+    )
+    assert user.has_role("role_edit")
+    assert user.has_any_role(["role_om", "role_edit"])
+    assert not user.has_role("role_master")
+
+
+def test_api_user_anonymous():
+    user = ApiUser.anonymous()
+    assert user.is_anonymous
+    assert not user.roles

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -13,6 +13,7 @@ import warnings
 
 from app.config import _build_tenant, _resolve_auth_mode
 from app.models.auth_models import ApiUser
+from app.utils.utils import DB_IDENTITY_CTX, DbIdentity, _resolve_db_identity
 
 
 def test_resolve_auth_mode_explicit_none():
@@ -59,3 +60,21 @@ def test_api_user_anonymous():
     user = ApiUser.anonymous()
     assert user.is_anonymous
     assert not user.roles
+
+
+def test_resolve_db_identity_without_context():
+    assert _resolve_db_identity() is None
+    assert _resolve_db_identity("alice") == "alice"
+    assert _resolve_db_identity("alice", "postgres") == "postgres"
+
+
+def test_resolve_db_identity_from_context():
+    token = DB_IDENTITY_CTX.set(DbIdentity(username="alice", db_role="postgres"))
+    try:
+        assert _resolve_db_identity() == "postgres"
+        assert _resolve_db_identity("anonymous") == "postgres"
+        assert _resolve_db_identity("bob") == "bob"
+        assert _resolve_db_identity("alice") == "postgres"
+        assert _resolve_db_identity("alice", "other") == "other"
+    finally:
+        DB_IDENTITY_CTX.reset(token)

--- a/tests/test_auth_smoke.py
+++ b/tests/test_auth_smoke.py
@@ -1,0 +1,234 @@
+"""
+Copyright © 2026 by BGEO. All rights reserved.
+The program is free software: you can redistribute it and/or modify it under the terms of the GNU
+General Public License as published by the Free Software Foundation, either version 3 of the License,
+or (at your option) any later version.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import textwrap
+from urllib.parse import quote
+
+from app.constants import ADMIN_PREFIX
+
+from tests.helpers import assert_ready
+
+
+def _run_subprocess(script: str) -> dict:
+    proc = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=os.getcwd(),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, f"subprocess failed: stderr={proc.stderr!r} stdout={proc.stdout!r}"
+    return json.loads(proc.stdout.strip().splitlines()[-1])
+
+
+def _tenant_env_body(auth_mode: str) -> str:
+    db_host = os.getenv("DB_HOST", "localhost")
+    db_port = os.getenv("DB_PORT", "5432")
+    db_name = os.getenv("DB_NAME", "gw_db")
+    db_user = os.getenv("DB_USER", "postgres")
+    db_password = os.getenv("DB_PASSWORD", "postgres")
+    db_schema = os.getenv("DB_SCHEMA", "public")
+    db_url = (
+        f"postgresql://{quote(db_user, safe='')}:{quote(db_password, safe='')}"
+        f"@{db_host}:{db_port}/{quote(db_name, safe='')}"
+        "?application_name=giswater-api&sslmode=disable"
+    )
+    return (
+        "API_BASIC=true\nAPI_PROFILE=true\nAPI_FLOW=true\nAPI_MINCUT=true\n"
+        "API_WATER_BALANCE=true\nAPI_MAPZONES=true\nAPI_ROUTING=true\n"
+        "API_CRM=true\nAPI_EPA=true\n"
+        f"DB_HOST={db_host}\nDB_PORT={db_port}\nDB_NAME={db_name}\n"
+        f"DB_USER={db_user}\nDB_PASSWORD={db_password}\nDB_SCHEMA={db_schema}\n"
+        f'DATABASE_URL="{db_url}"\n'
+        "DB_POOL_MIN_SIZE=1\nDB_POOL_MAX_SIZE=5\nDB_POOL_TIMEOUT=10\n"
+        "DB_CONNECT_TIMEOUT=5\n"
+        f"AUTH_MODE={auth_mode}\n"
+        f"AUTH_BASIC_BOOTSTRAP_USER={db_user}\n"
+        "AUTH_BASIC_BOOTSTRAP_PASSWORD=smokepass99\n"
+    )
+
+
+def _schema_param() -> str:
+    return os.getenv("DB_SCHEMA", "public")
+
+
+def _auth_subprocess_script(auth_mode: str, request_snippet: str) -> str:
+    tenants_dir = tempfile.mkdtemp(prefix="giswater-auth-smoke-")
+    env_path = os.path.join(tenants_dir, "smoke.env")
+    with open(env_path, "w", encoding="utf-8") as fh:
+        fh.write(_tenant_env_body(auth_mode))
+
+    return textwrap.dedent(
+        f"""
+        import json, os
+        os.environ["SINGLE_TENANT_ID"] = "smoke"
+        os.environ["TENANTS_DIR"] = {tenants_dir!r}
+        os.environ.setdefault("ADMIN_USER", "admin")
+        os.environ.setdefault("ADMIN_PASSWORD", "admin")
+        os.environ.setdefault("LOG_DB_ENABLED", "false")
+        os.environ.setdefault("GISWATER_DB_VERSION_CHECK", "false")
+
+        from fastapi.testclient import TestClient
+        from app.constants import TENANT_PREFIX
+        from app.main import app
+
+        with TestClient(
+            app,
+            base_url="http://127.0.0.1",
+            headers={{"X-Device": "5", "X-Lang": "en_US"}},
+        ) as c:
+        {textwrap.indent(request_snippet, "    ")}
+        """
+    )
+
+
+def test_basic_auth_missing_credentials_401():
+    schema = _schema_param()
+    script = _auth_subprocess_script(
+        "basic",
+        f"""
+        r = c.get(f"{{TENANT_PREFIX}}/basic/getlist", params={{"schema": {schema!r}}})
+        print(json.dumps({{"status": r.status_code}}))
+        """,
+    )
+    data = _run_subprocess(script)
+    assert data["status"] == 401
+
+
+def test_basic_auth_invalid_credentials_401():
+    schema = _schema_param()
+    script = _auth_subprocess_script(
+        "basic",
+        f"""
+        r = c.get(
+            f"{{TENANT_PREFIX}}/basic/getlist",
+            params={{"schema": {schema!r}}},
+            auth=("wrong", "credentials"),
+        )
+        print(json.dumps({{"status": r.status_code}}))
+        """,
+    )
+    data = _run_subprocess(script)
+    assert data["status"] == 401
+
+
+def test_none_mode_allows_anonymous():
+    schema = _schema_param()
+    script = _auth_subprocess_script(
+        "none",
+        f"""
+        r = c.get(f"{{TENANT_PREFIX}}/basic/getlist", params={{"schema": {schema!r}}})
+        print(json.dumps({{"status": r.status_code}}))
+        """,
+    )
+    data = _run_subprocess(script)
+    assert data["status"] != 401
+
+
+def test_basic_auth_valid_credentials(client, default_params):
+    """Requires Postgres; bootstrap user is created on tenant load."""
+    assert_ready(client)
+    schema = _schema_param()
+    bootstrap_user = os.getenv("DB_USER", "postgres")
+
+    script = _auth_subprocess_script(
+        "basic",
+        f"""
+        r = c.get(
+            f"{{TENANT_PREFIX}}/basic/getlist",
+            params={{"schema": {schema!r}, "tableName": "ve_arc"}},
+            auth=({bootstrap_user!r}, "smokepass99"),
+        )
+        print(json.dumps({{"status": r.status_code}}))
+        """,
+    )
+    data = _run_subprocess(script)
+    assert data["status"] == 200
+
+
+def test_admin_users_smoke(client):
+    """Admin user CRUD on a basic-auth tenant (requires Postgres)."""
+    assert_ready(client)
+    admin_headers = {"host": "bgeo360.com"}
+
+    pg_role = os.getenv("DB_USER", "postgres")
+    create_payload = {
+        "id": "authtest",
+        "api": {"basic": True},
+        "db": {
+            "host": os.getenv("DB_HOST", "localhost"),
+            "port": os.getenv("DB_PORT", "5432"),
+            "name": os.getenv("DB_NAME", "gw_db"),
+            "user": pg_role,
+            "password": os.getenv("DB_PASSWORD", "postgres"),
+            "schema": os.getenv("DB_SCHEMA", "public"),
+            "pool_min_size": 1,
+            "pool_max_size": 5,
+            "pool_timeout": 10,
+            "connect_timeout": 5,
+        },
+        "auth": {
+            "mode": "basic",
+            "bootstrapUser": pg_role,
+            "bootstrapPassword": "authtest99!",
+        },
+    }
+
+    created = client.post(
+        f"{ADMIN_PREFIX}/tenants",
+        json=create_payload,
+        headers=admin_headers,
+        auth=("admin", "admin"),
+    )
+    assert created.status_code == 201, created.text
+
+    try:
+        listed = client.get(
+            f"{ADMIN_PREFIX}/tenants/authtest/users",
+            headers=admin_headers,
+            auth=("admin", "admin"),
+        )
+        assert listed.status_code == 200
+        assert isinstance(listed.json(), list)
+
+        dup = client.post(
+            f"{ADMIN_PREFIX}/tenants/authtest/users",
+            json={
+                "username": "extra_user",
+                "password": "extrauser1",
+                "db_role": pg_role,
+                "roles": ["role_basic"],
+            },
+            headers=admin_headers,
+            auth=("admin", "admin"),
+        )
+        assert dup.status_code == 201
+
+        dup2 = client.post(
+            f"{ADMIN_PREFIX}/tenants/authtest/users",
+            json={
+                "username": "extra_user",
+                "password": "extrauser1",
+                "db_role": pg_role,
+                "roles": ["role_basic"],
+            },
+            headers=admin_headers,
+            auth=("admin", "admin"),
+        )
+        assert dup2.status_code == 400
+        assert "already exists" in dup2.json()["detail"].lower()
+    finally:
+        client.delete(
+            f"{ADMIN_PREFIX}/tenants/authtest",
+            headers=admin_headers,
+            auth=("admin", "admin"),
+        )


### PR DESCRIPTION
- Create a new environment variable `AUTH_MODE` (none, basic, keycloak).
- Deprecate `KEYCLOAK_ENABLED`.
- Basic auth mode uses schema `gwapi` (`gwapi.users`) to store users &
  roles, CRUD via admin API.
- Unified `ApiUser` identity class with dedicated FastAPI dependencies.
- Added `bcrypt` dependency for hashing passwords.