### PR TITLE
feat: add features endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,7 +39,7 @@ DB_MIGRATE_TIMEOUT=30
 
 # --- Optional DB readiness version gate (tenant GET $API_ROOT/v1/ready) ---
 GISWATER_DB_VERSION_CHECK=false
-GISWATER_DB_MIN_VERSION=4.8.0
+GISWATER_DB_MIN_VERSION=4.17.0
 
 # --- Rate limiting (max_requests<=0 disables) ---
 RATE_LIMIT_DEFAULT_MAX_REQUESTS=30
@@ -82,6 +82,7 @@ GUNICORN_CAPTURE_OUTPUT=true
 # =============================================================================
 # Per-tenant env keys (in config/tenants/<id>.env — NOT here): API_BASIC, API_PROFILE,
 # API_FLOW, API_MINCUT, API_WATER_BALANCE, API_MAPZONES, API_ROUTING, API_CRM, API_EPA,
+# API_FEATURES,
 # DB_HOST, DB_PORT, DB_NAME, DB_USER, DB_PASSWORD, DB_SCHEMA, DATABASE_URL,
 # DB_POOL_MIN_SIZE, DB_POOL_MAX_SIZE, DB_POOL_TIMEOUT, DB_POOL_MAX_WAITING,
 # DB_POOL_MAX_IDLE, DB_CONNECT_TIMEOUT,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,4 +72,5 @@ jobs:
           API_ROUTING: true
           API_CRM: true
           API_EPA: true
+          API_FEATURES: true
         run: pytest -v -m "not ${{ matrix.skip_marker }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **`/features` endpoints**: typed filters for nodes/arcs/links/connecs/gullies (list + GeoJSON + by-id), gated by `API_FEATURES`.
+- **`/features` endpoints**: typed filters for nodes/arcs/links/connecs/gullies (list + GeoJSON collection + by-id fields, form, and GeoJSON Feature), gated by `API_FEATURES`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **`GISWATER_DB_MIN_VERSION`** default raised to **4.17.0** (refactored `gw_fct_getfeatures` with `featureType` / `outputFormat`).
+- **`GISWATER_DB_MIN_VERSION`** default raised to **4.17.0** (refactored `gw_fct_getfeatures` with `featureType` / `outputFormat`). Compatibility table: **1.7.x → Giswater DB ≥ 4.17.0**.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **`/features` endpoints**: both json and geojson responses.
+- **`/features` endpoints**: typed filters for nodes/arcs/links/connecs/gullies (list + GeoJSON + by-id), gated by `API_FEATURES`.
+
+### Changed
+
+- **`GISWATER_DB_MIN_VERSION`** default raised to **4.17.0** (refactored `gw_fct_getfeatures` with `featureType` / `outputFormat`).
+
+### Deprecated
+
+- **`GET /om/dmas/{dma_id}/connecs`**: prefer `GET /features/connecs?dma_id={dma_id}`.
 
 ## [1.6.0] - 2026-06-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`/features` endpoints**: both json and geojson responses.
+
 ## [1.6.0] - 2026-06-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -54,12 +54,13 @@ Giswater API exposes a clean HTTP surface to query and operate a Giswater databa
 
 This service is versioned alongside the Giswater database. Use matching ranges to avoid subtle schema/API mismatches.
 
-| `giswater-api` version | Supported Giswater DB versions |
-| ---------------------- | ------------------------------ |
-| 0.1 – 0.7              | 4.0 – 4.7                      |
-| 0.8 – 1.x              | 4.8+                           |
+| `giswater-api` version | Supported Giswater DB versions | Notes |
+| ---------------------- | ------------------------------ | ----- |
+| 0.1 – 0.7              | 4.0 – 4.7                      | |
+| 0.8 – 1.6.x            | 4.8+                           | |
+| 1.7.x                  | 4.17+                          | `/features` needs refactored `gw_fct_getfeatures` (`featureType` / `outputFormat`). |
 
-When `GISWATER_DB_VERSION_CHECK=true`, tenant readiness (`GET ${API_ROOT}/v1/ready`) returns **503** if `{DB_SCHEMA}.sys_version` does not report a `giswater` version **≥** `GISWATER_DB_MIN_VERSION` (default `4.17.0`).
+When `GISWATER_DB_VERSION_CHECK=true`, tenant readiness (`GET ${API_ROOT}/v1/ready`) returns **503** if `{DB_SCHEMA}.sys_version` does not report a `giswater` version **≥** `GISWATER_DB_MIN_VERSION`. Set that variable to match the floor you want to enforce for each deployment.
 
 <a id="quick-start"></a>
 ## 🚀 Quick Start

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ This service is versioned alongside the Giswater database. Use matching ranges t
 | 0.1 – 0.7              | 4.0 – 4.7                      |
 | 0.8 – 1.x              | 4.8+                           |
 
-When `GISWATER_DB_VERSION_CHECK=true`, tenant readiness (`GET ${API_ROOT}/v1/ready`) returns **503** if `{DB_SCHEMA}.sys_version` does not report a `giswater` version **≥** `GISWATER_DB_MIN_VERSION` (default `4.8.0`).
+When `GISWATER_DB_VERSION_CHECK=true`, tenant readiness (`GET ${API_ROOT}/v1/ready`) returns **503** if `{DB_SCHEMA}.sys_version` does not report a `giswater` version **≥** `GISWATER_DB_MIN_VERSION` (default `4.17.0`).
 
 <a id="quick-start"></a>
 ## 🚀 Quick Start
@@ -338,6 +338,7 @@ All surfaces live under `${API_ROOT}` (default `/giswater`; override via the `AP
   - Admin: `${API_ROOT}/admin/docs` on apex host
 - Module routers are loaded from:
   - `basic`
+  - `features` (`nodes`, `arcs`, `links`, `connecs`, `gullies`)
   - `om` (`profile`, `flow`, `mincut`, `waterbalance`, `mapzones`)
   - `routing`
   - `crm`

--- a/app/api/v1/endpoints/features.py
+++ b/app/api/v1/endpoints/features.py
@@ -1,0 +1,177 @@
+"""
+Copyright © 2026 by BGEO. All rights reserved.
+The program is free software: you can redistribute it and/or modify it under the terms of the GNU
+General Public License as published by the Free Software Foundation, either version 3 of the License,
+or (at your option) any later version.
+"""
+
+from typing import Optional
+
+from fastapi import APIRouter, Path, Query
+
+from app.api.deps import CommonsDep, get_service_context
+from app.schemas.basic.basic_models import GetListResponse
+from app.schemas.features.feature_models import GetFeatureResponse
+from app.services.features_service import FeaturesService
+
+router = APIRouter(prefix="/features", tags=["Features"])
+
+
+@router.get(
+    "/nodes",
+    description="Get nodes",
+    response_model=GetListResponse,
+    response_model_exclude_unset=True,
+)
+async def get_nodes(
+    commons: CommonsDep,
+    coordinates: Optional[str] = Query(None, description="JSON string of coordinates (ExtentModel)"),
+    page_info: Optional[str] = Query(None, alias="pageInfo", description="JSON string of page info (PageInfoModel)"),
+    filter_fields: Optional[str] = Query(
+        None, alias="filterFields", description="JSON string of filter fields (Dict[str, FilterFieldModel])"
+    ),
+):
+    ctx = get_service_context(commons)
+    return await FeaturesService(ctx).get_features("node", coordinates, page_info, filter_fields)
+
+
+@router.get(
+    "/nodes/{node_id}",
+    description="Get a single node form",
+    response_model=GetFeatureResponse,
+    response_model_exclude_unset=True,
+)
+async def get_node(
+    commons: CommonsDep,
+    node_id: str = Path(..., description="Node id"),
+):
+    ctx = get_service_context(commons)
+    return await FeaturesService(ctx).get_feature("node", node_id)
+
+
+@router.get(
+    "/arcs",
+    description="Get arcs",
+    response_model=GetListResponse,
+    response_model_exclude_unset=True,
+)
+async def get_arcs(
+    commons: CommonsDep,
+    coordinates: Optional[str] = Query(None, description="JSON string of coordinates (ExtentModel)"),
+    page_info: Optional[str] = Query(None, alias="pageInfo", description="JSON string of page info (PageInfoModel)"),
+    filter_fields: Optional[str] = Query(
+        None, alias="filterFields", description="JSON string of filter fields (Dict[str, FilterFieldModel])"
+    ),
+):
+    ctx = get_service_context(commons)
+    return await FeaturesService(ctx).get_features("arc", coordinates, page_info, filter_fields)
+
+
+@router.get(
+    "/arcs/{arc_id}",
+    description="Get a single arc form",
+    response_model=GetFeatureResponse,
+    response_model_exclude_unset=True,
+)
+async def get_arc(
+    commons: CommonsDep,
+    arc_id: str = Path(..., description="Arc id"),
+):
+    ctx = get_service_context(commons)
+    return await FeaturesService(ctx).get_feature("arc", arc_id)
+
+
+@router.get(
+    "/links",
+    description="Get links",
+    response_model=GetListResponse,
+    response_model_exclude_unset=True,
+)
+async def get_links(
+    commons: CommonsDep,
+    coordinates: Optional[str] = Query(None, description="JSON string of coordinates (ExtentModel)"),
+    page_info: Optional[str] = Query(None, alias="pageInfo", description="JSON string of page info (PageInfoModel)"),
+    filter_fields: Optional[str] = Query(
+        None, alias="filterFields", description="JSON string of filter fields (Dict[str, FilterFieldModel])"
+    ),
+):
+    ctx = get_service_context(commons)
+    return await FeaturesService(ctx).get_features("link", coordinates, page_info, filter_fields)
+
+
+@router.get(
+    "/links/{link_id}",
+    description="Get a single link form",
+    response_model=GetFeatureResponse,
+    response_model_exclude_unset=True,
+)
+async def get_link(
+    commons: CommonsDep,
+    link_id: str = Path(..., description="Link id"),
+):
+    ctx = get_service_context(commons)
+    return await FeaturesService(ctx).get_feature("link", link_id)
+
+
+@router.get(
+    "/connecs",
+    description="Get connecs",
+    response_model=GetListResponse,
+    response_model_exclude_unset=True,
+)
+async def get_connecs(
+    commons: CommonsDep,
+    coordinates: Optional[str] = Query(None, description="JSON string of coordinates (ExtentModel)"),
+    page_info: Optional[str] = Query(None, alias="pageInfo", description="JSON string of page info (PageInfoModel)"),
+    filter_fields: Optional[str] = Query(
+        None, alias="filterFields", description="JSON string of filter fields (Dict[str, FilterFieldModel])"
+    ),
+):
+    ctx = get_service_context(commons)
+    return await FeaturesService(ctx).get_features("connec", coordinates, page_info, filter_fields)
+
+
+@router.get(
+    "/connecs/{connec_id}",
+    description="Get a single connec form",
+    response_model=GetFeatureResponse,
+    response_model_exclude_unset=True,
+)
+async def get_connec(
+    commons: CommonsDep,
+    connec_id: str = Path(..., description="Connec id"),
+):
+    ctx = get_service_context(commons)
+    return await FeaturesService(ctx).get_feature("connec", connec_id)
+
+
+@router.get(
+    "/gullys",
+    description="Get gullys",
+    response_model=GetListResponse,
+    response_model_exclude_unset=True,
+)
+async def get_gullys(
+    commons: CommonsDep,
+    coordinates: Optional[str] = Query(None, description="JSON string of coordinates (ExtentModel)"),
+    page_info: Optional[str] = Query(None, alias="pageInfo", description="JSON string of page info (PageInfoModel)"),
+    filter_fields: Optional[str] = Query(
+        None, alias="filterFields", description="JSON string of filter fields (Dict[str, FilterFieldModel])"
+    ),
+):
+    ctx = get_service_context(commons)
+    return await FeaturesService(ctx).get_features("gully", coordinates, page_info, filter_fields)
+
+
+@router.get(
+    "/gullys/{gully_id}",
+    description="Get a single gully form",
+    response_model=GetFeatureResponse,
+    response_model_exclude_unset=True,
+)
+async def get_gully(
+    commons: CommonsDep,
+    gully_id: str = Path(..., description="Gully id"),
+):
+    ctx = get_service_context(commons)
+    return await FeaturesService(ctx).get_feature("gully", gully_id)

--- a/app/api/v1/endpoints/features.py
+++ b/app/api/v1/endpoints/features.py
@@ -5,63 +5,165 @@ General Public License as published by the Free Software Foundation, either vers
 or (at your option) any later version.
 """
 
-from typing import Optional
+from __future__ import annotations
 
-from fastapi import APIRouter, Path, Query
+import inspect
+from typing import Annotated, Any, Callable, Literal, Optional, Type, TypeVar
+
+from fastapi import APIRouter, Depends, Path, Query, Request
+from fastapi.exceptions import RequestValidationError
+from pydantic import ValidationError
+from pydantic_core import PydanticUndefined
 
 from app.api.deps import CommonsDep, get_service_context
-from app.schemas.basic.basic_models import GetListResponse
-from app.schemas.features.feature_models import GetFeatureResponse, GetFeaturesGeoJsonResponse
+from app.schemas.features.feature_models import (
+    ArcFilters,
+    ConnecFilters,
+    FeatureFilters,
+    GetFeatureResponse,
+    GetFeaturesGeoJsonResponse,
+    GetFeaturesResponse,
+    GullyFilters,
+    LinkFilters,
+    NodeFilters,
+)
 from app.services.features_service import FeaturesService
 
 router = APIRouter(prefix="/features", tags=["Features"])
 
+_LIMIT = Query(100, ge=1, le=5000, title="Limit", description="Maximum number of features to return")
+_COORDINATES = Query(
+    None,
+    title="Coordinates",
+    description="JSON string of map extent (ExtentModel: x1, y1, x2, y2)",
+)
+_ORDER_TYPE = Query(None, alias="orderType", title="Order type", description="ASC or DESC")
+
+_RESERVED_QUERY_KEYS = frozenset({"schema", "coordinates", "orderBy", "orderType", "limit"})
+
+NodeOrderBy = Literal["node_id", "code", "sys_type", "node_type", "nodecat_id", "dma_id", "sector_id", "state"]
+ArcOrderBy = Literal["arc_id", "code", "sys_type", "arc_type", "arccat_id", "dma_id", "sector_id", "state"]
+LinkOrderBy = Literal["link_id", "code", "sys_type", "link_type", "dma_id", "sector_id", "state"]
+ConnecOrderBy = Literal["connec_id", "code", "sys_type", "connec_type", "connecat_id", "dma_id", "sector_id", "state"]
+GullyOrderBy = Literal["gully_id", "code", "sys_type", "gully_type", "gratecat_id", "dma_id", "sector_id", "state"]
+
+F = TypeVar("F", bound=FeatureFilters)
+
+
+def _reject_unknown_filters(request: Request, model_cls: Type[FeatureFilters]) -> None:
+    allowed = set(model_cls.model_fields) | _RESERVED_QUERY_KEYS
+    unknown = sorted({key for key in request.query_params.keys() if key not in allowed})
+    if not unknown:
+        return
+    raise RequestValidationError(
+        [
+            {
+                "type": "extra_forbidden",
+                "loc": ["query", key],
+                "msg": "Extra inputs are not permitted",
+                "input": request.query_params.get(key),
+            }
+            for key in unknown
+        ]
+    )
+
+
+def make_filters_dependency(model_cls: Type[F]) -> Callable[..., F]:
+    """Build a Depends callable whose signature exposes model fields for OpenAPI.
+
+    FastAPI only expands a Pydantic query model when it is the sole query param.
+    CommonsDep always injects ``schema``, so filters must be a Depends instead.
+    """
+
+    parameters: list[inspect.Parameter] = [
+        inspect.Parameter("request", inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=Request)
+    ]
+    for name, field in model_cls.model_fields.items():
+        default = field.default
+        if default is PydanticUndefined:
+            default = None
+        query_default = Query(default, description=field.description)
+        parameters.append(
+            inspect.Parameter(
+                name,
+                inspect.Parameter.KEYWORD_ONLY,
+                default=query_default,
+                annotation=field.annotation,
+            )
+        )
+
+    async def _dependency(request: Request, **kwargs: Any) -> F:
+        _reject_unknown_filters(request, model_cls)
+        try:
+            return model_cls.model_validate(kwargs)
+        except ValidationError as exc:
+            raise RequestValidationError(exc.errors()) from exc
+
+    _dependency.__signature__ = inspect.Signature(parameters, return_annotation=model_cls)  # type: ignore[attr-defined]
+    _dependency.__annotations__ = {p.name: p.annotation for p in parameters} | {"return": model_cls}
+    return _dependency
+
+
+NodeFiltersDep = Annotated[NodeFilters, Depends(make_filters_dependency(NodeFilters))]
+ArcFiltersDep = Annotated[ArcFilters, Depends(make_filters_dependency(ArcFilters))]
+LinkFiltersDep = Annotated[LinkFilters, Depends(make_filters_dependency(LinkFilters))]
+ConnecFiltersDep = Annotated[ConnecFilters, Depends(make_filters_dependency(ConnecFilters))]
+GullyFiltersDep = Annotated[GullyFilters, Depends(make_filters_dependency(GullyFilters))]
+
 
 @router.get(
     "/nodes",
-    description="Get nodes",
-    response_model=GetListResponse,
+    description=(
+        "Returns a filtered collection of nodes from ve_node. "
+        "Use sys_type for feature-class groups (e.g. VALVE) and node_type for subtypes "
+        "(e.g. CHECK_VALVE). Mapzone filters such as dma_id and sector_id are supported."
+    ),
+    response_model=GetFeaturesResponse,
     response_model_exclude_unset=True,
 )
 async def get_nodes(
     commons: CommonsDep,
-    coordinates: Optional[str] = Query(None, description="JSON string of coordinates (ExtentModel)"),
-    page_info: Optional[str] = Query(None, alias="pageInfo", description="JSON string of page info (PageInfoModel)"),
-    filter_fields: Optional[str] = Query(
-        None, alias="filterFields", description="JSON string of filter fields (Dict[str, FilterFieldModel])"
-    ),
+    filters: NodeFiltersDep,
+    coordinates: Optional[str] = _COORDINATES,
+    order_by: Optional[NodeOrderBy] = Query(None, alias="orderBy", title="Order by"),
+    order_type: Optional[Literal["ASC", "DESC"]] = _ORDER_TYPE,
+    limit: int = _LIMIT,
 ):
     ctx = get_service_context(commons)
-    return await FeaturesService(ctx).get_features("node", coordinates, page_info, filter_fields)
+    return await FeaturesService(ctx).list_features(
+        "node", filters, coordinates=coordinates, order_by=order_by, order_type=order_type, limit=limit
+    )
 
 
 @router.get(
     "/nodes/geojson",
-    description="Get nodes as GeoJSON",
+    description=("Returns nodes as a GeoJSON FeatureCollection, with the same filters as GET /features/nodes."),
     response_model=GetFeaturesGeoJsonResponse,
     response_model_exclude_unset=True,
 )
 async def get_nodes_geojson(
     commons: CommonsDep,
-    coordinates: Optional[str] = Query(None, description="JSON string of coordinates (ExtentModel)"),
-    page_info: Optional[str] = Query(None, alias="pageInfo", description="JSON string of page info (PageInfoModel)"),
-    filter_fields: Optional[str] = Query(
-        None, alias="filterFields", description="JSON string of filter fields (Dict[str, FilterFieldModel])"
-    ),
+    filters: NodeFiltersDep,
+    coordinates: Optional[str] = _COORDINATES,
+    order_by: Optional[NodeOrderBy] = Query(None, alias="orderBy", title="Order by"),
+    order_type: Optional[Literal["ASC", "DESC"]] = _ORDER_TYPE,
+    limit: int = _LIMIT,
 ):
     ctx = get_service_context(commons)
-    return await FeaturesService(ctx).get_features_geojson("node", coordinates, page_info, filter_fields)
+    return await FeaturesService(ctx).list_features_geojson(
+        "node", filters, coordinates=coordinates, order_by=order_by, order_type=order_type, limit=limit
+    )
 
 
 @router.get(
     "/nodes/{node_id}",
-    description="Get a single node form",
+    description="Returns the form/info payload for a single node (gw_fct_getinfofromid).",
     response_model=GetFeatureResponse,
     response_model_exclude_unset=True,
 )
 async def get_node(
     commons: CommonsDep,
-    node_id: str = Path(..., description="Node id"),
+    node_id: str = Path(..., title="Node id", description="The unique identifier of the node", examples=["1001"]),
 ):
     ctx = get_service_context(commons)
     return await FeaturesService(ctx).get_feature("node", node_id)
@@ -69,49 +171,56 @@ async def get_node(
 
 @router.get(
     "/arcs",
-    description="Get arcs",
-    response_model=GetListResponse,
+    description=(
+        "Returns a filtered collection of arcs from ve_arc. "
+        "Filter by mapzones (dma_id, sector_id, …), sys_type, arc_type, or catalog fields."
+    ),
+    response_model=GetFeaturesResponse,
     response_model_exclude_unset=True,
 )
 async def get_arcs(
     commons: CommonsDep,
-    coordinates: Optional[str] = Query(None, description="JSON string of coordinates (ExtentModel)"),
-    page_info: Optional[str] = Query(None, alias="pageInfo", description="JSON string of page info (PageInfoModel)"),
-    filter_fields: Optional[str] = Query(
-        None, alias="filterFields", description="JSON string of filter fields (Dict[str, FilterFieldModel])"
-    ),
+    filters: ArcFiltersDep,
+    coordinates: Optional[str] = _COORDINATES,
+    order_by: Optional[ArcOrderBy] = Query(None, alias="orderBy", title="Order by"),
+    order_type: Optional[Literal["ASC", "DESC"]] = _ORDER_TYPE,
+    limit: int = _LIMIT,
 ):
     ctx = get_service_context(commons)
-    return await FeaturesService(ctx).get_features("arc", coordinates, page_info, filter_fields)
+    return await FeaturesService(ctx).list_features(
+        "arc", filters, coordinates=coordinates, order_by=order_by, order_type=order_type, limit=limit
+    )
 
 
 @router.get(
     "/arcs/geojson",
-    description="Get arcs as GeoJSON",
+    description=("Returns arcs as a GeoJSON FeatureCollection, with the same filters as GET /features/arcs."),
     response_model=GetFeaturesGeoJsonResponse,
     response_model_exclude_unset=True,
 )
 async def get_arcs_geojson(
     commons: CommonsDep,
-    coordinates: Optional[str] = Query(None, description="JSON string of coordinates (ExtentModel)"),
-    page_info: Optional[str] = Query(None, alias="pageInfo", description="JSON string of page info (PageInfoModel)"),
-    filter_fields: Optional[str] = Query(
-        None, alias="filterFields", description="JSON string of filter fields (Dict[str, FilterFieldModel])"
-    ),
+    filters: ArcFiltersDep,
+    coordinates: Optional[str] = _COORDINATES,
+    order_by: Optional[ArcOrderBy] = Query(None, alias="orderBy", title="Order by"),
+    order_type: Optional[Literal["ASC", "DESC"]] = _ORDER_TYPE,
+    limit: int = _LIMIT,
 ):
     ctx = get_service_context(commons)
-    return await FeaturesService(ctx).get_features_geojson("arc", coordinates, page_info, filter_fields)
+    return await FeaturesService(ctx).list_features_geojson(
+        "arc", filters, coordinates=coordinates, order_by=order_by, order_type=order_type, limit=limit
+    )
 
 
 @router.get(
     "/arcs/{arc_id}",
-    description="Get a single arc form",
+    description="Returns the form/info payload for a single arc (gw_fct_getinfofromid).",
     response_model=GetFeatureResponse,
     response_model_exclude_unset=True,
 )
 async def get_arc(
     commons: CommonsDep,
-    arc_id: str = Path(..., description="Arc id"),
+    arc_id: str = Path(..., title="Arc id", description="The unique identifier of the arc", examples=["2001"]),
 ):
     ctx = get_service_context(commons)
     return await FeaturesService(ctx).get_feature("arc", arc_id)
@@ -119,49 +228,53 @@ async def get_arc(
 
 @router.get(
     "/links",
-    description="Get links",
-    response_model=GetListResponse,
+    description=("Returns a filtered collection of links from ve_link. Filter by mapzones, sys_type, or link_type."),
+    response_model=GetFeaturesResponse,
     response_model_exclude_unset=True,
 )
 async def get_links(
     commons: CommonsDep,
-    coordinates: Optional[str] = Query(None, description="JSON string of coordinates (ExtentModel)"),
-    page_info: Optional[str] = Query(None, alias="pageInfo", description="JSON string of page info (PageInfoModel)"),
-    filter_fields: Optional[str] = Query(
-        None, alias="filterFields", description="JSON string of filter fields (Dict[str, FilterFieldModel])"
-    ),
+    filters: LinkFiltersDep,
+    coordinates: Optional[str] = _COORDINATES,
+    order_by: Optional[LinkOrderBy] = Query(None, alias="orderBy", title="Order by"),
+    order_type: Optional[Literal["ASC", "DESC"]] = _ORDER_TYPE,
+    limit: int = _LIMIT,
 ):
     ctx = get_service_context(commons)
-    return await FeaturesService(ctx).get_features("link", coordinates, page_info, filter_fields)
+    return await FeaturesService(ctx).list_features(
+        "link", filters, coordinates=coordinates, order_by=order_by, order_type=order_type, limit=limit
+    )
 
 
 @router.get(
     "/links/geojson",
-    description="Get links as GeoJSON",
+    description=("Returns links as a GeoJSON FeatureCollection, with the same filters as GET /features/links."),
     response_model=GetFeaturesGeoJsonResponse,
     response_model_exclude_unset=True,
 )
 async def get_links_geojson(
     commons: CommonsDep,
-    coordinates: Optional[str] = Query(None, description="JSON string of coordinates (ExtentModel)"),
-    page_info: Optional[str] = Query(None, alias="pageInfo", description="JSON string of page info (PageInfoModel)"),
-    filter_fields: Optional[str] = Query(
-        None, alias="filterFields", description="JSON string of filter fields (Dict[str, FilterFieldModel])"
-    ),
+    filters: LinkFiltersDep,
+    coordinates: Optional[str] = _COORDINATES,
+    order_by: Optional[LinkOrderBy] = Query(None, alias="orderBy", title="Order by"),
+    order_type: Optional[Literal["ASC", "DESC"]] = _ORDER_TYPE,
+    limit: int = _LIMIT,
 ):
     ctx = get_service_context(commons)
-    return await FeaturesService(ctx).get_features_geojson("link", coordinates, page_info, filter_fields)
+    return await FeaturesService(ctx).list_features_geojson(
+        "link", filters, coordinates=coordinates, order_by=order_by, order_type=order_type, limit=limit
+    )
 
 
 @router.get(
     "/links/{link_id}",
-    description="Get a single link form",
+    description="Returns the form/info payload for a single link (gw_fct_getinfofromid).",
     response_model=GetFeatureResponse,
     response_model_exclude_unset=True,
 )
 async def get_link(
     commons: CommonsDep,
-    link_id: str = Path(..., description="Link id"),
+    link_id: str = Path(..., title="Link id", description="The unique identifier of the link", examples=["3001"]),
 ):
     ctx = get_service_context(commons)
     return await FeaturesService(ctx).get_feature("link", link_id)
@@ -169,99 +282,117 @@ async def get_link(
 
 @router.get(
     "/connecs",
-    description="Get connecs",
-    response_model=GetListResponse,
+    description=(
+        "Returns a filtered collection of connecs from ve_connec. "
+        "Filter by mapzones (dma_id, sector_id, …), sys_type, connec_type, or customer_code."
+    ),
+    response_model=GetFeaturesResponse,
     response_model_exclude_unset=True,
 )
 async def get_connecs(
     commons: CommonsDep,
-    coordinates: Optional[str] = Query(None, description="JSON string of coordinates (ExtentModel)"),
-    page_info: Optional[str] = Query(None, alias="pageInfo", description="JSON string of page info (PageInfoModel)"),
-    filter_fields: Optional[str] = Query(
-        None, alias="filterFields", description="JSON string of filter fields (Dict[str, FilterFieldModel])"
-    ),
+    filters: ConnecFiltersDep,
+    coordinates: Optional[str] = _COORDINATES,
+    order_by: Optional[ConnecOrderBy] = Query(None, alias="orderBy", title="Order by"),
+    order_type: Optional[Literal["ASC", "DESC"]] = _ORDER_TYPE,
+    limit: int = _LIMIT,
 ):
     ctx = get_service_context(commons)
-    return await FeaturesService(ctx).get_features("connec", coordinates, page_info, filter_fields)
+    return await FeaturesService(ctx).list_features(
+        "connec", filters, coordinates=coordinates, order_by=order_by, order_type=order_type, limit=limit
+    )
 
 
 @router.get(
     "/connecs/geojson",
-    description="Get connecs as GeoJSON",
+    description=("Returns connecs as a GeoJSON FeatureCollection, with the same filters as GET /features/connecs."),
     response_model=GetFeaturesGeoJsonResponse,
     response_model_exclude_unset=True,
 )
 async def get_connecs_geojson(
     commons: CommonsDep,
-    coordinates: Optional[str] = Query(None, description="JSON string of coordinates (ExtentModel)"),
-    page_info: Optional[str] = Query(None, alias="pageInfo", description="JSON string of page info (PageInfoModel)"),
-    filter_fields: Optional[str] = Query(
-        None, alias="filterFields", description="JSON string of filter fields (Dict[str, FilterFieldModel])"
-    ),
+    filters: ConnecFiltersDep,
+    coordinates: Optional[str] = _COORDINATES,
+    order_by: Optional[ConnecOrderBy] = Query(None, alias="orderBy", title="Order by"),
+    order_type: Optional[Literal["ASC", "DESC"]] = _ORDER_TYPE,
+    limit: int = _LIMIT,
 ):
     ctx = get_service_context(commons)
-    return await FeaturesService(ctx).get_features_geojson("connec", coordinates, page_info, filter_fields)
+    return await FeaturesService(ctx).list_features_geojson(
+        "connec", filters, coordinates=coordinates, order_by=order_by, order_type=order_type, limit=limit
+    )
 
 
 @router.get(
     "/connecs/{connec_id}",
-    description="Get a single connec form",
+    description="Returns the form/info payload for a single connec (gw_fct_getinfofromid).",
     response_model=GetFeatureResponse,
     response_model_exclude_unset=True,
 )
 async def get_connec(
     commons: CommonsDep,
-    connec_id: str = Path(..., description="Connec id"),
+    connec_id: str = Path(..., title="Connec id", description="The unique identifier of the connec", examples=["4001"]),
 ):
     ctx = get_service_context(commons)
     return await FeaturesService(ctx).get_feature("connec", connec_id)
 
 
 @router.get(
-    "/gullys",
-    description="Get gullys",
-    response_model=GetListResponse,
+    "/gullies",
+    description=(
+        "Returns a filtered collection of gullies from ve_gully. "
+        "UD (urban drainage) schemas only — ve_gully does not exist on water-supply (WS) schemas. "
+        "Filter by mapzones, sys_type, gully_type, or gratecat_id."
+    ),
+    response_model=GetFeaturesResponse,
     response_model_exclude_unset=True,
 )
-async def get_gullys(
+async def get_gullies(
     commons: CommonsDep,
-    coordinates: Optional[str] = Query(None, description="JSON string of coordinates (ExtentModel)"),
-    page_info: Optional[str] = Query(None, alias="pageInfo", description="JSON string of page info (PageInfoModel)"),
-    filter_fields: Optional[str] = Query(
-        None, alias="filterFields", description="JSON string of filter fields (Dict[str, FilterFieldModel])"
-    ),
+    filters: GullyFiltersDep,
+    coordinates: Optional[str] = _COORDINATES,
+    order_by: Optional[GullyOrderBy] = Query(None, alias="orderBy", title="Order by"),
+    order_type: Optional[Literal["ASC", "DESC"]] = _ORDER_TYPE,
+    limit: int = _LIMIT,
 ):
     ctx = get_service_context(commons)
-    return await FeaturesService(ctx).get_features("gully", coordinates, page_info, filter_fields)
+    return await FeaturesService(ctx).list_features(
+        "gully", filters, coordinates=coordinates, order_by=order_by, order_type=order_type, limit=limit
+    )
 
 
 @router.get(
-    "/gullys/geojson",
-    description="Get gullys as GeoJSON",
+    "/gullies/geojson",
+    description=(
+        "Returns gullies as a GeoJSON FeatureCollection, with the same filters as GET /features/gullies. "
+        "UD schemas only."
+    ),
     response_model=GetFeaturesGeoJsonResponse,
     response_model_exclude_unset=True,
 )
-async def get_gullys_geojson(
+async def get_gullies_geojson(
     commons: CommonsDep,
-    coordinates: Optional[str] = Query(None, description="JSON string of coordinates (ExtentModel)"),
-    page_info: Optional[str] = Query(None, alias="pageInfo", description="JSON string of page info (PageInfoModel)"),
-    filter_fields: Optional[str] = Query(
-        None, alias="filterFields", description="JSON string of filter fields (Dict[str, FilterFieldModel])"
-    ),
+    filters: GullyFiltersDep,
+    coordinates: Optional[str] = _COORDINATES,
+    order_by: Optional[GullyOrderBy] = Query(None, alias="orderBy", title="Order by"),
+    order_type: Optional[Literal["ASC", "DESC"]] = _ORDER_TYPE,
+    limit: int = _LIMIT,
 ):
     ctx = get_service_context(commons)
-    return await FeaturesService(ctx).get_features_geojson("gully", coordinates, page_info, filter_fields)
+    return await FeaturesService(ctx).list_features_geojson(
+        "gully", filters, coordinates=coordinates, order_by=order_by, order_type=order_type, limit=limit
+    )
 
 
 @router.get(
-    "/gullys/{gully_id}",
-    description="Get a single gully form",
+    "/gullies/{gully_id}",
+    description="Returns the form/info payload for a single gully (gw_fct_getinfofromid). UD schemas only.",
     response_model=GetFeatureResponse,
     response_model_exclude_unset=True,
 )
 async def get_gully(
     commons: CommonsDep,
-    gully_id: str = Path(..., description="Gully id"),
+    gully_id: str = Path(..., title="Gully id", description="The unique identifier of the gully", examples=["5001"]),
 ):
     ctx = get_service_context(commons)
     return await FeaturesService(ctx).get_feature("gully", gully_id)

--- a/app/api/v1/endpoints/features.py
+++ b/app/api/v1/endpoints/features.py
@@ -11,7 +11,7 @@ from fastapi import APIRouter, Path, Query
 
 from app.api.deps import CommonsDep, get_service_context
 from app.schemas.basic.basic_models import GetListResponse
-from app.schemas.features.feature_models import GetFeatureResponse
+from app.schemas.features.feature_models import GetFeatureResponse, GetFeaturesGeoJsonResponse
 from app.services.features_service import FeaturesService
 
 router = APIRouter(prefix="/features", tags=["Features"])
@@ -33,6 +33,24 @@ async def get_nodes(
 ):
     ctx = get_service_context(commons)
     return await FeaturesService(ctx).get_features("node", coordinates, page_info, filter_fields)
+
+
+@router.get(
+    "/nodes/geojson",
+    description="Get nodes as GeoJSON",
+    response_model=GetFeaturesGeoJsonResponse,
+    response_model_exclude_unset=True,
+)
+async def get_nodes_geojson(
+    commons: CommonsDep,
+    coordinates: Optional[str] = Query(None, description="JSON string of coordinates (ExtentModel)"),
+    page_info: Optional[str] = Query(None, alias="pageInfo", description="JSON string of page info (PageInfoModel)"),
+    filter_fields: Optional[str] = Query(
+        None, alias="filterFields", description="JSON string of filter fields (Dict[str, FilterFieldModel])"
+    ),
+):
+    ctx = get_service_context(commons)
+    return await FeaturesService(ctx).get_features_geojson("node", coordinates, page_info, filter_fields)
 
 
 @router.get(
@@ -68,6 +86,24 @@ async def get_arcs(
 
 
 @router.get(
+    "/arcs/geojson",
+    description="Get arcs as GeoJSON",
+    response_model=GetFeaturesGeoJsonResponse,
+    response_model_exclude_unset=True,
+)
+async def get_arcs_geojson(
+    commons: CommonsDep,
+    coordinates: Optional[str] = Query(None, description="JSON string of coordinates (ExtentModel)"),
+    page_info: Optional[str] = Query(None, alias="pageInfo", description="JSON string of page info (PageInfoModel)"),
+    filter_fields: Optional[str] = Query(
+        None, alias="filterFields", description="JSON string of filter fields (Dict[str, FilterFieldModel])"
+    ),
+):
+    ctx = get_service_context(commons)
+    return await FeaturesService(ctx).get_features_geojson("arc", coordinates, page_info, filter_fields)
+
+
+@router.get(
     "/arcs/{arc_id}",
     description="Get a single arc form",
     response_model=GetFeatureResponse,
@@ -97,6 +133,24 @@ async def get_links(
 ):
     ctx = get_service_context(commons)
     return await FeaturesService(ctx).get_features("link", coordinates, page_info, filter_fields)
+
+
+@router.get(
+    "/links/geojson",
+    description="Get links as GeoJSON",
+    response_model=GetFeaturesGeoJsonResponse,
+    response_model_exclude_unset=True,
+)
+async def get_links_geojson(
+    commons: CommonsDep,
+    coordinates: Optional[str] = Query(None, description="JSON string of coordinates (ExtentModel)"),
+    page_info: Optional[str] = Query(None, alias="pageInfo", description="JSON string of page info (PageInfoModel)"),
+    filter_fields: Optional[str] = Query(
+        None, alias="filterFields", description="JSON string of filter fields (Dict[str, FilterFieldModel])"
+    ),
+):
+    ctx = get_service_context(commons)
+    return await FeaturesService(ctx).get_features_geojson("link", coordinates, page_info, filter_fields)
 
 
 @router.get(
@@ -132,6 +186,24 @@ async def get_connecs(
 
 
 @router.get(
+    "/connecs/geojson",
+    description="Get connecs as GeoJSON",
+    response_model=GetFeaturesGeoJsonResponse,
+    response_model_exclude_unset=True,
+)
+async def get_connecs_geojson(
+    commons: CommonsDep,
+    coordinates: Optional[str] = Query(None, description="JSON string of coordinates (ExtentModel)"),
+    page_info: Optional[str] = Query(None, alias="pageInfo", description="JSON string of page info (PageInfoModel)"),
+    filter_fields: Optional[str] = Query(
+        None, alias="filterFields", description="JSON string of filter fields (Dict[str, FilterFieldModel])"
+    ),
+):
+    ctx = get_service_context(commons)
+    return await FeaturesService(ctx).get_features_geojson("connec", coordinates, page_info, filter_fields)
+
+
+@router.get(
     "/connecs/{connec_id}",
     description="Get a single connec form",
     response_model=GetFeatureResponse,
@@ -161,6 +233,24 @@ async def get_gullys(
 ):
     ctx = get_service_context(commons)
     return await FeaturesService(ctx).get_features("gully", coordinates, page_info, filter_fields)
+
+
+@router.get(
+    "/gullys/geojson",
+    description="Get gullys as GeoJSON",
+    response_model=GetFeaturesGeoJsonResponse,
+    response_model_exclude_unset=True,
+)
+async def get_gullys_geojson(
+    commons: CommonsDep,
+    coordinates: Optional[str] = Query(None, description="JSON string of coordinates (ExtentModel)"),
+    page_info: Optional[str] = Query(None, alias="pageInfo", description="JSON string of page info (PageInfoModel)"),
+    filter_fields: Optional[str] = Query(
+        None, alias="filterFields", description="JSON string of filter fields (Dict[str, FilterFieldModel])"
+    ),
+):
+    ctx = get_service_context(commons)
+    return await FeaturesService(ctx).get_features_geojson("gully", coordinates, page_info, filter_fields)
 
 
 @router.get(

--- a/app/api/v1/endpoints/features.py
+++ b/app/api/v1/endpoints/features.py
@@ -20,6 +20,8 @@ from app.schemas.features.feature_models import (
     ArcFilters,
     ConnecFilters,
     FeatureFilters,
+    GetFeatureFieldsResponse,
+    GetFeatureGeoJsonResponse,
     GetFeatureResponse,
     GetFeaturesGeoJsonResponse,
     GetFeaturesResponse,
@@ -38,6 +40,12 @@ _COORDINATES = Query(
     description="JSON string of map extent (ExtentModel: x1, y1, x2, y2)",
 )
 _ORDER_TYPE = Query(None, alias="orderType", title="Order type", description="ASC or DESC")
+
+_NODE_ID = Path(..., title="Node id", description="The unique identifier of the node", examples=["1001"])
+_ARC_ID = Path(..., title="Arc id", description="The unique identifier of the arc", examples=["2001"])
+_LINK_ID = Path(..., title="Link id", description="The unique identifier of the link", examples=["3001"])
+_CONNEC_ID = Path(..., title="Connec id", description="The unique identifier of the connec", examples=["4001"])
+_GULLY_ID = Path(..., title="Gully id", description="The unique identifier of the gully", examples=["5001"])
 
 _RESERVED_QUERY_KEYS = frozenset({"schema", "coordinates", "orderBy", "orderType", "limit"})
 
@@ -157,16 +165,44 @@ async def get_nodes_geojson(
 
 @router.get(
     "/nodes/{node_id}",
-    description="Returns the form/info payload for a single node (gw_fct_getinfofromid).",
-    response_model=GetFeatureResponse,
+    description="Returns a single node row from ve_node, same fields as GET /features/nodes.",
+    response_model=GetFeatureFieldsResponse,
     response_model_exclude_unset=True,
 )
 async def get_node(
     commons: CommonsDep,
-    node_id: str = Path(..., title="Node id", description="The unique identifier of the node", examples=["1001"]),
+    node_id: str = _NODE_ID,
 ):
     ctx = get_service_context(commons)
-    return await FeaturesService(ctx).get_feature("node", node_id)
+    return await FeaturesService(ctx).get_feature_fields("node", node_id)
+
+
+@router.get(
+    "/nodes/{node_id}/form",
+    description="Returns the form/info payload for a single node (gw_fct_getinfofromid).",
+    response_model=GetFeatureResponse,
+    response_model_exclude_unset=True,
+)
+async def get_node_form(
+    commons: CommonsDep,
+    node_id: str = _NODE_ID,
+):
+    ctx = get_service_context(commons)
+    return await FeaturesService(ctx).get_feature_form("node", node_id)
+
+
+@router.get(
+    "/nodes/{node_id}/geojson",
+    description="Returns a single node as a GeoJSON Feature.",
+    response_model=GetFeatureGeoJsonResponse,
+    response_model_exclude_unset=True,
+)
+async def get_node_geojson_by_id(
+    commons: CommonsDep,
+    node_id: str = _NODE_ID,
+):
+    ctx = get_service_context(commons)
+    return await FeaturesService(ctx).get_feature_geojson("node", node_id)
 
 
 @router.get(
@@ -214,16 +250,44 @@ async def get_arcs_geojson(
 
 @router.get(
     "/arcs/{arc_id}",
-    description="Returns the form/info payload for a single arc (gw_fct_getinfofromid).",
-    response_model=GetFeatureResponse,
+    description="Returns a single arc row from ve_arc, same fields as GET /features/arcs.",
+    response_model=GetFeatureFieldsResponse,
     response_model_exclude_unset=True,
 )
 async def get_arc(
     commons: CommonsDep,
-    arc_id: str = Path(..., title="Arc id", description="The unique identifier of the arc", examples=["2001"]),
+    arc_id: str = _ARC_ID,
 ):
     ctx = get_service_context(commons)
-    return await FeaturesService(ctx).get_feature("arc", arc_id)
+    return await FeaturesService(ctx).get_feature_fields("arc", arc_id)
+
+
+@router.get(
+    "/arcs/{arc_id}/form",
+    description="Returns the form/info payload for a single arc (gw_fct_getinfofromid).",
+    response_model=GetFeatureResponse,
+    response_model_exclude_unset=True,
+)
+async def get_arc_form(
+    commons: CommonsDep,
+    arc_id: str = _ARC_ID,
+):
+    ctx = get_service_context(commons)
+    return await FeaturesService(ctx).get_feature_form("arc", arc_id)
+
+
+@router.get(
+    "/arcs/{arc_id}/geojson",
+    description="Returns a single arc as a GeoJSON Feature.",
+    response_model=GetFeatureGeoJsonResponse,
+    response_model_exclude_unset=True,
+)
+async def get_arc_geojson_by_id(
+    commons: CommonsDep,
+    arc_id: str = _ARC_ID,
+):
+    ctx = get_service_context(commons)
+    return await FeaturesService(ctx).get_feature_geojson("arc", arc_id)
 
 
 @router.get(
@@ -268,16 +332,44 @@ async def get_links_geojson(
 
 @router.get(
     "/links/{link_id}",
-    description="Returns the form/info payload for a single link (gw_fct_getinfofromid).",
-    response_model=GetFeatureResponse,
+    description="Returns a single link row from ve_link, same fields as GET /features/links.",
+    response_model=GetFeatureFieldsResponse,
     response_model_exclude_unset=True,
 )
 async def get_link(
     commons: CommonsDep,
-    link_id: str = Path(..., title="Link id", description="The unique identifier of the link", examples=["3001"]),
+    link_id: str = _LINK_ID,
 ):
     ctx = get_service_context(commons)
-    return await FeaturesService(ctx).get_feature("link", link_id)
+    return await FeaturesService(ctx).get_feature_fields("link", link_id)
+
+
+@router.get(
+    "/links/{link_id}/form",
+    description="Returns the form/info payload for a single link (gw_fct_getinfofromid).",
+    response_model=GetFeatureResponse,
+    response_model_exclude_unset=True,
+)
+async def get_link_form(
+    commons: CommonsDep,
+    link_id: str = _LINK_ID,
+):
+    ctx = get_service_context(commons)
+    return await FeaturesService(ctx).get_feature_form("link", link_id)
+
+
+@router.get(
+    "/links/{link_id}/geojson",
+    description="Returns a single link as a GeoJSON Feature.",
+    response_model=GetFeatureGeoJsonResponse,
+    response_model_exclude_unset=True,
+)
+async def get_link_geojson_by_id(
+    commons: CommonsDep,
+    link_id: str = _LINK_ID,
+):
+    ctx = get_service_context(commons)
+    return await FeaturesService(ctx).get_feature_geojson("link", link_id)
 
 
 @router.get(
@@ -325,16 +417,44 @@ async def get_connecs_geojson(
 
 @router.get(
     "/connecs/{connec_id}",
-    description="Returns the form/info payload for a single connec (gw_fct_getinfofromid).",
-    response_model=GetFeatureResponse,
+    description="Returns a single connec row from ve_connec, same fields as GET /features/connecs.",
+    response_model=GetFeatureFieldsResponse,
     response_model_exclude_unset=True,
 )
 async def get_connec(
     commons: CommonsDep,
-    connec_id: str = Path(..., title="Connec id", description="The unique identifier of the connec", examples=["4001"]),
+    connec_id: str = _CONNEC_ID,
 ):
     ctx = get_service_context(commons)
-    return await FeaturesService(ctx).get_feature("connec", connec_id)
+    return await FeaturesService(ctx).get_feature_fields("connec", connec_id)
+
+
+@router.get(
+    "/connecs/{connec_id}/form",
+    description="Returns the form/info payload for a single connec (gw_fct_getinfofromid).",
+    response_model=GetFeatureResponse,
+    response_model_exclude_unset=True,
+)
+async def get_connec_form(
+    commons: CommonsDep,
+    connec_id: str = _CONNEC_ID,
+):
+    ctx = get_service_context(commons)
+    return await FeaturesService(ctx).get_feature_form("connec", connec_id)
+
+
+@router.get(
+    "/connecs/{connec_id}/geojson",
+    description="Returns a single connec as a GeoJSON Feature.",
+    response_model=GetFeatureGeoJsonResponse,
+    response_model_exclude_unset=True,
+)
+async def get_connec_geojson_by_id(
+    commons: CommonsDep,
+    connec_id: str = _CONNEC_ID,
+):
+    ctx = get_service_context(commons)
+    return await FeaturesService(ctx).get_feature_geojson("connec", connec_id)
 
 
 @router.get(
@@ -386,13 +506,41 @@ async def get_gullies_geojson(
 
 @router.get(
     "/gullies/{gully_id}",
-    description="Returns the form/info payload for a single gully (gw_fct_getinfofromid). UD schemas only.",
-    response_model=GetFeatureResponse,
+    description="Returns a single gully row from ve_gully, same fields as GET /features/gullies. UD schemas only.",
+    response_model=GetFeatureFieldsResponse,
     response_model_exclude_unset=True,
 )
 async def get_gully(
     commons: CommonsDep,
-    gully_id: str = Path(..., title="Gully id", description="The unique identifier of the gully", examples=["5001"]),
+    gully_id: str = _GULLY_ID,
 ):
     ctx = get_service_context(commons)
-    return await FeaturesService(ctx).get_feature("gully", gully_id)
+    return await FeaturesService(ctx).get_feature_fields("gully", gully_id)
+
+
+@router.get(
+    "/gullies/{gully_id}/form",
+    description="Returns the form/info payload for a single gully (gw_fct_getinfofromid). UD schemas only.",
+    response_model=GetFeatureResponse,
+    response_model_exclude_unset=True,
+)
+async def get_gully_form(
+    commons: CommonsDep,
+    gully_id: str = _GULLY_ID,
+):
+    ctx = get_service_context(commons)
+    return await FeaturesService(ctx).get_feature_form("gully", gully_id)
+
+
+@router.get(
+    "/gullies/{gully_id}/geojson",
+    description="Returns a single gully as a GeoJSON Feature. UD schemas only.",
+    response_model=GetFeatureGeoJsonResponse,
+    response_model_exclude_unset=True,
+)
+async def get_gully_geojson_by_id(
+    commons: CommonsDep,
+    gully_id: str = _GULLY_ID,
+):
+    ctx = get_service_context(commons)
+    return await FeaturesService(ctx).get_feature_geojson("gully", gully_id)

--- a/app/api/v1/endpoints/om/mapzones/dma.py
+++ b/app/api/v1/endpoints/om/mapzones/dma.py
@@ -83,7 +83,11 @@ async def get_dma_parameters(
 
 @router.get(
     "/dmas/{dma_id}/connecs",
-    description=("Returns a collection of connecs within a specific DMA, providing details from ve_connec."),
+    description=(
+        "Deprecated: prefer GET /features/connecs?dma_id={dma_id}. "
+        "Returns a collection of connecs within a specific DMA, providing details from ve_connec."
+    ),
+    deprecated=True,
     response_model=GetDmaConnecsResponse,
     response_model_exclude_unset=True,
 )

--- a/app/api/v1/router.py
+++ b/app/api/v1/router.py
@@ -12,7 +12,7 @@ from fastapi import APIRouter, Depends, FastAPI
 from starlette.routing import BaseRoute
 
 from app.api.deps import require_feature
-from app.api.v1.endpoints import basic, crm, system
+from app.api.v1.endpoints import basic, crm, features, system
 from app.api.v1.endpoints.epa import dscenario
 from app.api.v1.endpoints.om import flow, mincut, profile, waterbalance
 from app.api.v1.endpoints.om.mapzones import dma, dqa, omunit, omzone, presszone, sector
@@ -22,6 +22,7 @@ from app.tenancy.registry import Tenant
 # Tuple list: `APIRouter` is not hashable in Python 3.13+ (cannot use as dict keys).
 ROUTER_FEATURES: list[tuple[APIRouter, str]] = [
     (basic.router, "api_basic"),
+    (features.router, "api_features"),
     (profile.router, "api_profile"),
     (flow.router, "api_flow"),
     (mincut.router, "api_mincut"),

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -172,6 +172,7 @@ class TenantSettings:
     api_routing: bool = False
     api_crm: bool = False
     api_epa: bool = False
+    api_features: bool = False
 
     # Database
     db_host: str = "localhost"
@@ -296,6 +297,7 @@ def _build_tenant(env: Mapping[str, str | None]) -> TenantSettings:
         api_routing=_to_bool(env.get("API_ROUTING"), False),
         api_crm=_to_bool(env.get("API_CRM"), False),
         api_epa=_to_bool(env.get("API_EPA"), False),
+        api_features=_to_bool(env.get("API_FEATURES"), False),
         db_host=(env.get("DB_HOST") or "localhost"),
         db_port=(env.get("DB_PORT") or "5432"),
         db_name=(env.get("DB_NAME") or "postgres"),

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -140,7 +140,7 @@ class GlobalSettings:
 
     # DB compatibility (optional readiness gate; see GISWATER_DB_* env vars)
     giswater_db_version_check: bool = False
-    giswater_db_min_version: str = "4.8.0"
+    giswater_db_min_version: str = "4.17.0"
 
     # Alembic migrations for the API-owned `gwapi` schema.
     # When True, `alembic upgrade head` runs per tenant on load. Set False to
@@ -280,7 +280,7 @@ def _build_global(env: Mapping[str, str | None]) -> GlobalSettings:
         platform_keycloak_client_id=env.get("PLATFORM_KEYCLOAK_CLIENT_ID") or None,
         platform_keycloak_client_secret=env.get("PLATFORM_KEYCLOAK_CLIENT_SECRET") or None,
         giswater_db_version_check=_to_bool(env.get("GISWATER_DB_VERSION_CHECK"), False),
-        giswater_db_min_version=(env.get("GISWATER_DB_MIN_VERSION") or "4.8.0"),
+        giswater_db_min_version=(env.get("GISWATER_DB_MIN_VERSION") or "4.17.0"),
         db_auto_migrate=_to_bool(env.get("DB_AUTO_MIGRATE"), True),
         db_migrate_timeout=_to_float(env.get("DB_MIGRATE_TIMEOUT"), 30.0),
     )

--- a/app/schemas/admin.py
+++ b/app/schemas/admin.py
@@ -131,6 +131,7 @@ class TenantOut(BaseModel):
             "routing": s.api_routing,
             "crm": s.api_crm,
             "epa": s.api_epa,
+            "features": s.api_features,
         }
         db = DbSettingsOut(
             host=s.db_host,
@@ -238,6 +239,7 @@ def build_tenant_settings_from_input(
         api_routing=_api("routing"),
         api_crm=_api("crm"),
         api_epa=_api("epa"),
+        api_features=_api("features"),
         db_host=db.host,
         db_port=db.port,
         db_name=db.name,

--- a/app/schemas/common.py
+++ b/app/schemas/common.py
@@ -319,9 +319,11 @@ class PageInfoReturnModel(BaseModel):
 
 
 class FilterFieldModel(BaseModel):
-    """Filter field model"""
+    """Filter field model.
 
-    value: Any = Field(..., description="Value")
-    filterSign: Literal["=", ">", "<", ">=", "<=", "LIKE", "ILIKE", "BETWEEN", "IN"] = Field(
-        "=", description="Filter sign"
-    )
+    ``filterSign=IN`` expects ``value`` to be a JSON array (e.g. ``["A","B"]``).
+    ``BETWEEN`` is not supported by ``gw_fct_build_filters_sql`` via this model.
+    """
+
+    value: Any = Field(..., description="Value (array when filterSign is IN)")
+    filterSign: Literal["=", ">", "<", ">=", "<=", "LIKE", "ILIKE", "IN"] = Field("=", description="Filter sign")

--- a/app/schemas/features/feature_models.py
+++ b/app/schemas/features/feature_models.py
@@ -1,0 +1,42 @@
+"""
+Copyright © 2026 by BGEO. All rights reserved.
+The program is free software: you can redistribute it and/or modify it under the terms of the GNU
+General Public License as published by the Free Software Foundation, either version 3 of the License,
+or (at your option) any later version.
+"""
+
+from typing import Dict, Literal
+
+from ..common import BaseAPIResponse, Body, Data
+
+FeatureType = Literal["node", "arc", "link", "connec", "gully"]
+
+FEATURE_TABLE_MAP: Dict[FeatureType, str] = {
+    "node": "ve_node",
+    "arc": "ve_arc",
+    "link": "ve_link",
+    "connec": "ve_connec",
+    "gully": "ve_gully",
+}
+
+FEATURE_ID_MAP: Dict[FeatureType, str] = {
+    "node": "node_id",
+    "arc": "arc_id",
+    "link": "link_id",
+    "connec": "connec_id",
+    "gully": "gully_id",
+}
+
+
+def get_feature_table(feature_type: FeatureType) -> str:
+    return FEATURE_TABLE_MAP[feature_type]
+
+
+def get_feature_id_column(feature_type: FeatureType) -> str:
+    return FEATURE_ID_MAP[feature_type]
+
+
+class GetFeatureResponse(BaseAPIResponse[Body[Data]]):
+    """Response model for a single feature form (gw_fct_getinfofromid)."""
+
+    pass

--- a/app/schemas/features/feature_models.py
+++ b/app/schemas/features/feature_models.py
@@ -104,6 +104,42 @@ class GetFeatureResponse(BaseAPIResponse[Body[Data]]):
     pass
 
 
+class GetFeatureFieldsData(Data):
+    """Single feature row (gw_fct_getfeatures, outputFormat=list, filtered by id)."""
+
+    feature: Optional[Dict[str, Any]] = Field(None, description="Feature row")
+
+
+class GetFeatureFieldsBody(Body[GetFeatureFieldsData]):
+    form: Optional[Dict] = Field(default_factory=dict, description="Form")
+    feature: Optional[Dict] = Field(default_factory=dict, description="Feature")
+
+
+class GetFeatureFieldsResponse(BaseAPIResponse[GetFeatureFieldsBody]):
+    """Response model for a single feature row (gw_fct_getfeatures, outputFormat=list)."""
+
+    pass
+
+
+class GetFeatureGeoJsonData(Data):
+    """Single GeoJSON Feature."""
+
+    type: Optional[Literal["Feature"]] = Field(None, description="GeoJSON type")
+    geometry: Optional[Dict[str, Any]] = Field(None, description="GeoJSON geometry")
+    properties: Optional[Dict[str, Any]] = Field(None, description="Feature attributes")
+
+
+class GetFeatureGeoJsonBody(Body[GetFeatureGeoJsonData]):
+    form: Optional[Dict] = Field(default_factory=dict, description="Form")
+    feature: Optional[Dict] = Field(default_factory=dict, description="Feature")
+
+
+class GetFeatureGeoJsonResponse(BaseAPIResponse[GetFeatureGeoJsonBody]):
+    """Response model for a single feature as GeoJSON (gw_fct_getfeatures, outputFormat=geojson)."""
+
+    pass
+
+
 class GetFeaturesData(Data):
     """List payload returned by gw_fct_getfeatures with outputFormat=list."""
 

--- a/app/schemas/features/feature_models.py
+++ b/app/schemas/features/feature_models.py
@@ -5,9 +5,11 @@ General Public License as published by the Free Software Foundation, either vers
 or (at your option) any later version.
 """
 
-from typing import Dict, Literal
+from typing import Any, Dict, List, Literal, Optional
 
-from ..common import BaseAPIResponse, Body, Data
+from pydantic import Field
+
+from ..common import BaseAPIResponse, Body, Data, PageInfoReturnModel
 
 FeatureType = Literal["node", "arc", "link", "connec", "gully"]
 
@@ -38,5 +40,24 @@ def get_feature_id_column(feature_type: FeatureType) -> str:
 
 class GetFeatureResponse(BaseAPIResponse[Body[Data]]):
     """Response model for a single feature form (gw_fct_getinfofromid)."""
+
+    pass
+
+
+class GetFeaturesGeoJsonData(Data):
+    """GeoJSON feature collection returned by gw_fct_getfeatures."""
+
+    type: Optional[Literal["FeatureCollection"]] = Field(None, description="GeoJSON type")
+    features: Optional[List[Dict[str, Any]]] = Field(None, description="GeoJSON features")
+    pageInfo: Optional[PageInfoReturnModel] = Field(None, description="Pagination information")
+
+
+class GetFeaturesGeoJsonBody(Body[GetFeaturesGeoJsonData]):
+    form: Optional[Dict] = Field(default_factory=dict, description="Form")
+    feature: Optional[Dict] = Field(default_factory=dict, description="Feature")
+
+
+class GetFeaturesGeoJsonResponse(BaseAPIResponse[GetFeaturesGeoJsonBody]):
+    """Response model for feature geometries as GeoJSON (gw_fct_getfeatures)."""
 
     pass

--- a/app/schemas/features/feature_models.py
+++ b/app/schemas/features/feature_models.py
@@ -7,18 +7,18 @@ or (at your option) any later version.
 
 from typing import Any, Dict, List, Literal, Optional
 
-from pydantic import Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from ..common import BaseAPIResponse, Body, Data, PageInfoReturnModel
 
 FeatureType = Literal["node", "arc", "link", "connec", "gully"]
 
-FEATURE_TABLE_MAP: Dict[FeatureType, str] = {
-    "node": "ve_node",
-    "arc": "ve_arc",
-    "link": "ve_link",
-    "connec": "ve_connec",
-    "gully": "ve_gully",
+FEATURE_TYPE_PARAM: Dict[FeatureType, str] = {
+    "node": "NODE",
+    "arc": "ARC",
+    "link": "LINK",
+    "connec": "CONNEC",
+    "gully": "GULLY",
 }
 
 FEATURE_ID_MAP: Dict[FeatureType, str] = {
@@ -30,16 +30,94 @@ FEATURE_ID_MAP: Dict[FeatureType, str] = {
 }
 
 
+def get_feature_type_param(feature_type: FeatureType) -> str:
+    return FEATURE_TYPE_PARAM[feature_type]
+
+
 def get_feature_table(feature_type: FeatureType) -> str:
-    return FEATURE_TABLE_MAP[feature_type]
+    return f"ve_{feature_type}"
 
 
 def get_feature_id_column(feature_type: FeatureType) -> str:
     return FEATURE_ID_MAP[feature_type]
 
 
+class FeatureFilters(BaseModel):
+    """Shared filter fields present on all feature views."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    expl_id: Optional[int] = Field(None, description="Exploitation id")
+    macroexpl_id: Optional[int] = Field(None, description="Macroexploitation id")
+    sector_id: Optional[int] = Field(None, description="Sector id")
+    macrosector_id: Optional[int] = Field(None, description="Macrosector id")
+    dma_id: Optional[int] = Field(None, description="DMA id")
+    macrodma_id: Optional[int] = Field(None, description="Macro DMA id")
+    presszone_id: Optional[str] = Field(None, description="Pressure zone id")
+    dqa_id: Optional[int] = Field(None, description="DQA id")
+    state: Optional[int] = Field(None, description="Feature state")
+    sys_type: Optional[List[str]] = Field(
+        None, description="System type / feature class group (e.g. VALVE, PIPE, JUNCTION)"
+    )
+    code: Optional[str] = Field(None, description="Feature code")
+
+    def to_filter_fields(self) -> dict[str, dict]:
+        out: dict[str, dict] = {}
+        for key, value in self.model_dump(exclude_none=True).items():
+            if isinstance(value, list):
+                out[key] = {"value": value, "filterSign": "IN"}
+            else:
+                out[key] = {"value": value, "filterSign": "="}
+        return out
+
+
+class NodeFilters(FeatureFilters):
+    node_type: Optional[List[str]] = Field(None, description="Node type (cat_feature.id subtype)")
+    nodecat_id: Optional[List[str]] = Field(None, description="Node catalog id")
+
+
+class ArcFilters(FeatureFilters):
+    arc_type: Optional[List[str]] = Field(None, description="Arc type")
+    arccat_id: Optional[List[str]] = Field(None, description="Arc catalog id")
+    cat_matcat_id: Optional[str] = Field(None, description="Material catalog id")
+    cat_dnom: Optional[str] = Field(None, description="Nominal diameter")
+
+
+class ConnecFilters(FeatureFilters):
+    connec_type: Optional[List[str]] = Field(None, description="Connec type")
+    connecat_id: Optional[List[str]] = Field(None, description="Connec catalog id")
+    customer_code: Optional[str] = Field(None, description="Customer code")
+
+
+class GullyFilters(FeatureFilters):
+    gully_type: Optional[List[str]] = Field(None, description="Gully type")
+    gratecat_id: Optional[List[str]] = Field(None, description="Grate catalog id")
+
+
+class LinkFilters(FeatureFilters):
+    link_type: Optional[List[str]] = Field(None, description="Link type")
+
+
 class GetFeatureResponse(BaseAPIResponse[Body[Data]]):
     """Response model for a single feature form (gw_fct_getinfofromid)."""
+
+    pass
+
+
+class GetFeaturesData(Data):
+    """List payload returned by gw_fct_getfeatures with outputFormat=list."""
+
+    features: Optional[List[Dict[str, Any]]] = Field(None, description="Feature rows")
+    pageInfo: Optional[PageInfoReturnModel] = Field(None, description="Pagination information")
+
+
+class GetFeaturesBody(Body[GetFeaturesData]):
+    form: Optional[Dict] = Field(default_factory=dict, description="Form")
+    feature: Optional[Dict] = Field(default_factory=dict, description="Feature")
+
+
+class GetFeaturesResponse(BaseAPIResponse[GetFeaturesBody]):
+    """Response model for feature lists (gw_fct_getfeatures, outputFormat=list)."""
 
     pass
 

--- a/app/services/basic_service.py
+++ b/app/services/basic_service.py
@@ -138,13 +138,12 @@ class BasicService:
         )
         return await run_procedure(self.ctx, "gw_fct_getarcauditvalues", body)
 
-    async def get_list(
+    def _parse_list_query_params(
         self,
-        table_name: str,
         coordinates: Optional[str] = None,
         page_info: Optional[str] = None,
         filter_fields: Optional[str] = None,
-    ) -> dict:
+    ) -> tuple[Optional[dict], Optional[dict], Optional[dict]]:
         try:
             coordinates_data = None
             if coordinates:
@@ -166,6 +165,19 @@ class BasicService:
         except ValidationError as exc:
             raise InvalidParametersError(str(exc)) from exc
 
+        return coordinates_data, page_info_data, filter_fields_data
+
+    async def get_list(
+        self,
+        table_name: str,
+        coordinates: Optional[str] = None,
+        page_info: Optional[str] = None,
+        filter_fields: Optional[str] = None,
+    ) -> dict:
+        coordinates_data, page_info_data, filter_fields_data = self._parse_list_query_params(
+            coordinates, page_info, filter_fields
+        )
+
         data = {"tableName": table_name}
         if coordinates:
             data["canvasExtend"] = coordinates_data
@@ -177,3 +189,29 @@ class BasicService:
             cur_user=self.ctx.user_id,
         )
         return await run_procedure(self.ctx, "gw_fct_getlist", body)
+
+    async def get_features(
+        self,
+        table_name: str,
+        coordinates: Optional[str] = None,
+        page_info: Optional[str] = None,
+        filter_fields: Optional[str] = None,
+        output_format: Literal["geojson"] = "geojson",
+    ) -> dict:
+        coordinates_data, page_info_data, filter_fields_data = self._parse_list_query_params(
+            coordinates, page_info, filter_fields
+        )
+
+        data = {"tableName": table_name, "outputFormat": output_format}
+        if coordinates:
+            data["canvasExtend"] = coordinates_data
+
+        body = create_body_dict(
+            device=self.ctx.device,
+            lang=self.ctx.lang,
+            extras=data,
+            filter_fields=filter_fields_data if filter_fields_data else {},
+            page_info=page_info_data if page_info_data else {},
+            cur_user=self.ctx.user_id,
+        )
+        return await run_procedure(self.ctx, "gw_fct_getfeatures", body)

--- a/app/services/basic_service.py
+++ b/app/services/basic_service.py
@@ -179,31 +179,7 @@ class BasicService:
         )
 
         data = {"tableName": table_name}
-        if coordinates:
-            data["canvasExtend"] = coordinates_data
-
-        body = create_body_dict(
-            extras=data,
-            filter_fields=filter_fields_data if filter_fields_data else {},
-            page_info=page_info_data if page_info_data else {},
-            cur_user=self.ctx.user_id,
-        )
-        return await run_procedure(self.ctx, "gw_fct_getlist", body)
-
-    async def get_features(
-        self,
-        table_name: str,
-        coordinates: Optional[str] = None,
-        page_info: Optional[str] = None,
-        filter_fields: Optional[str] = None,
-        output_format: Literal["geojson"] = "geojson",
-    ) -> dict:
-        coordinates_data, page_info_data, filter_fields_data = self._parse_list_query_params(
-            coordinates, page_info, filter_fields
-        )
-
-        data = {"tableName": table_name, "outputFormat": output_format}
-        if coordinates:
+        if coordinates_data is not None:
             data["canvasExtend"] = coordinates_data
 
         body = create_body_dict(
@@ -214,4 +190,4 @@ class BasicService:
             page_info=page_info_data if page_info_data else {},
             cur_user=self.ctx.user_id,
         )
-        return await run_procedure(self.ctx, "gw_fct_getfeatures", body)
+        return await run_procedure(self.ctx, "gw_fct_getlist", body)

--- a/app/services/features_service.py
+++ b/app/services/features_service.py
@@ -1,0 +1,53 @@
+"""
+Copyright © 2026 by BGEO. All rights reserved.
+The program is free software: you can redistribute it and/or modify it under the terms of the GNU
+General Public License as published by the Free Software Foundation, either version 3 of the License,
+or (at your option) any later version.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from app.schemas.features.feature_models import (
+    FeatureType,
+    get_feature_id_column,
+    get_feature_table,
+)
+from app.services.basic_service import BasicService
+from app.services.context import ServiceContext
+from app.services.procedure import run_procedure
+from app.utils.body import create_body_dict
+
+
+class FeaturesService:
+    def __init__(self, ctx: ServiceContext):
+        self.ctx = ctx.with_logger(__name__)
+        self._basic = BasicService(self.ctx)
+
+    async def get_features(
+        self,
+        feature_type: FeatureType,
+        coordinates: Optional[str] = None,
+        page_info: Optional[str] = None,
+        filter_fields: Optional[str] = None,
+    ) -> dict:
+        return await self._basic.get_list(
+            get_feature_table(feature_type),
+            coordinates=coordinates,
+            page_info=page_info,
+            filter_fields=filter_fields,
+        )
+
+    async def get_feature(self, feature_type: FeatureType, feature_id: str) -> dict:
+        body = create_body_dict(
+            device=self.ctx.device,
+            lang=self.ctx.lang,
+            feature={
+                "tableName": get_feature_table(feature_type),
+                "id": feature_id,
+                "idName": get_feature_id_column(feature_type),
+            },
+            cur_user=self.ctx.user_id,
+        )
+        return await run_procedure(self.ctx, "gw_fct_getinfofromid", body)

--- a/app/services/features_service.py
+++ b/app/services/features_service.py
@@ -51,3 +51,17 @@ class FeaturesService:
             cur_user=self.ctx.user_id,
         )
         return await run_procedure(self.ctx, "gw_fct_getinfofromid", body)
+
+    async def get_features_geojson(
+        self,
+        feature_type: FeatureType,
+        coordinates: Optional[str] = None,
+        page_info: Optional[str] = None,
+        filter_fields: Optional[str] = None,
+    ) -> dict:
+        return await self._basic.get_features(
+            get_feature_table(feature_type),
+            coordinates=coordinates,
+            page_info=page_info,
+            filter_fields=filter_fields,
+        )

--- a/app/services/features_service.py
+++ b/app/services/features_service.py
@@ -118,7 +118,40 @@ class FeaturesService:
             limit=limit,
         )
 
-    async def get_feature(self, feature_type: FeatureType, feature_id: str) -> dict:
+    async def _get_feature_by_id(
+        self,
+        feature_type: FeatureType,
+        feature_id: str,
+        output_format: Literal["list", "geojson"],
+    ) -> tuple[dict, dict]:
+        body = create_body_dict(
+            device=self._effective_device(),
+            lang=self.ctx.lang,
+            extras={
+                "featureType": get_feature_type_param(feature_type),
+                "outputFormat": output_format,
+            },
+            filter_fields={get_feature_id_column(feature_type): {"value": [feature_id], "filterSign": "IN"}},
+            page_info={"limit": 1},
+            cur_user=self.ctx.user_id,
+        )
+        result = await run_procedure(self.ctx, "gw_fct_getfeatures", body)
+        features = ((result.get("body") or {}).get("data") or {}).get("features") or []
+        if not features:
+            raise LookupError(f"{feature_type} '{feature_id}' not found")
+        return result, features[0]
+
+    async def get_feature_fields(self, feature_type: FeatureType, feature_id: str) -> dict:
+        result, feature = await self._get_feature_by_id(feature_type, feature_id, "list")
+        result["body"]["data"] = {"feature": feature}
+        return result
+
+    async def get_feature_geojson(self, feature_type: FeatureType, feature_id: str) -> dict:
+        result, feature = await self._get_feature_by_id(feature_type, feature_id, "geojson")
+        result["body"]["data"] = feature
+        return result
+
+    async def get_feature_form(self, feature_type: FeatureType, feature_id: str) -> dict:
         body = create_body_dict(
             device=self.ctx.device,
             lang=self.ctx.lang,

--- a/app/services/features_service.py
+++ b/app/services/features_service.py
@@ -7,36 +7,115 @@ or (at your option) any later version.
 
 from __future__ import annotations
 
-from typing import Optional
+import json
+from typing import Literal, Optional
 
+from pydantic import ValidationError
+
+from app.core.exceptions import InvalidParametersError
+from app.schemas.common import ExtentModel
 from app.schemas.features.feature_models import (
+    FeatureFilters,
     FeatureType,
     get_feature_id_column,
     get_feature_table,
+    get_feature_type_param,
 )
-from app.services.basic_service import BasicService
 from app.services.context import ServiceContext
 from app.services.procedure import run_procedure
 from app.utils.body import create_body_dict
+
+# gw_fct_getfeatures only applies LIMIT when device != 4 (QGIS Desktop).
+_FEATURES_DEVICE_FALLBACK = 5
+_DEFAULT_LIMIT = 500
 
 
 class FeaturesService:
     def __init__(self, ctx: ServiceContext):
         self.ctx = ctx.with_logger(__name__)
-        self._basic = BasicService(self.ctx)
 
-    async def get_features(
+    def _effective_device(self) -> int:
+        return self.ctx.device if self.ctx.device != 4 else _FEATURES_DEVICE_FALLBACK
+
+    def _parse_coordinates(self, coordinates: Optional[str]) -> Optional[dict]:
+        if not coordinates:
+            return None
+        try:
+            return ExtentModel(**json.loads(coordinates)).model_dump(mode="json", exclude_unset=True)
+        except (ValidationError, json.JSONDecodeError, TypeError) as exc:
+            raise InvalidParametersError(str(exc)) from exc
+
+    async def _list_features(
         self,
         feature_type: FeatureType,
+        output_format: Literal["list", "geojson"],
+        filters: FeatureFilters,
         coordinates: Optional[str] = None,
-        page_info: Optional[str] = None,
-        filter_fields: Optional[str] = None,
+        order_by: Optional[str] = None,
+        order_type: Optional[Literal["ASC", "DESC"]] = None,
+        limit: int = _DEFAULT_LIMIT,
     ) -> dict:
-        return await self._basic.get_list(
-            get_feature_table(feature_type),
-            coordinates=coordinates,
-            page_info=page_info,
+        coordinates_data = self._parse_coordinates(coordinates)
+        filter_fields = filters.to_filter_fields()
+
+        page_info: dict = {"limit": limit}
+        if order_by:
+            page_info["orderBy"] = order_by
+            page_info["orderType"] = order_type or "ASC"
+
+        extras: dict = {
+            "featureType": get_feature_type_param(feature_type),
+            "outputFormat": output_format,
+        }
+        if coordinates_data is not None:
+            extras["canvasExtend"] = coordinates_data
+
+        body = create_body_dict(
+            device=self._effective_device(),
+            lang=self.ctx.lang,
+            extras=extras,
             filter_fields=filter_fields,
+            page_info=page_info,
+            cur_user=self.ctx.user_id,
+        )
+        return await run_procedure(self.ctx, "gw_fct_getfeatures", body)
+
+    async def list_features(
+        self,
+        feature_type: FeatureType,
+        filters: FeatureFilters,
+        coordinates: Optional[str] = None,
+        order_by: Optional[str] = None,
+        order_type: Optional[Literal["ASC", "DESC"]] = None,
+        limit: int = _DEFAULT_LIMIT,
+    ) -> dict:
+        return await self._list_features(
+            feature_type,
+            "list",
+            filters,
+            coordinates=coordinates,
+            order_by=order_by,
+            order_type=order_type,
+            limit=limit,
+        )
+
+    async def list_features_geojson(
+        self,
+        feature_type: FeatureType,
+        filters: FeatureFilters,
+        coordinates: Optional[str] = None,
+        order_by: Optional[str] = None,
+        order_type: Optional[Literal["ASC", "DESC"]] = None,
+        limit: int = _DEFAULT_LIMIT,
+    ) -> dict:
+        return await self._list_features(
+            feature_type,
+            "geojson",
+            filters,
+            coordinates=coordinates,
+            order_by=order_by,
+            order_type=order_type,
+            limit=limit,
         )
 
     async def get_feature(self, feature_type: FeatureType, feature_id: str) -> dict:
@@ -51,17 +130,3 @@ class FeaturesService:
             cur_user=self.ctx.user_id,
         )
         return await run_procedure(self.ctx, "gw_fct_getinfofromid", body)
-
-    async def get_features_geojson(
-        self,
-        feature_type: FeatureType,
-        coordinates: Optional[str] = None,
-        page_info: Optional[str] = None,
-        filter_fields: Optional[str] = None,
-    ) -> dict:
-        return await self._basic.get_features(
-            get_feature_table(feature_type),
-            coordinates=coordinates,
-            page_info=page_info,
-            filter_fields=filter_fields,
-        )

--- a/app/tenancy/registry.py
+++ b/app/tenancy/registry.py
@@ -99,6 +99,7 @@ def serialize_tenant_settings(settings: TenantSettings) -> str:
         ("API_ROUTING", settings.api_routing),
         ("API_CRM", settings.api_crm),
         ("API_EPA", settings.api_epa),
+        ("API_FEATURES", settings.api_features),
         ("DB_HOST", settings.db_host),
         ("DB_PORT", settings.db_port),
         ("DB_NAME", settings.db_name),

--- a/config/tenants/example.env
+++ b/config/tenants/example.env
@@ -20,6 +20,7 @@ API_MAPZONES=true
 API_ROUTING=true
 API_CRM=true
 API_EPA=true
+API_FEATURES=true
 
 # Database
 DB_HOST=localhost

--- a/deploy/.env.prod.example
+++ b/deploy/.env.prod.example
@@ -43,7 +43,7 @@ PLATFORM_KEYCLOAK_CLIENT_SECRET=
 
 # --- DB readiness gate ---
 GISWATER_DB_VERSION_CHECK=true
-GISWATER_DB_MIN_VERSION=4.8.0
+GISWATER_DB_MIN_VERSION=4.17.0
 
 # --- Gunicorn (production Docker CMD; see gunicorn.conf.py) ---
 GUNICORN_BIND=0.0.0.0:8000

--- a/deploy/main.env.example
+++ b/deploy/main.env.example
@@ -11,6 +11,7 @@ API_MAPZONES=true
 API_ROUTING=true
 API_CRM=true
 API_EPA=true
+API_FEATURES=true
 
 # Database
 DB_HOST=host.docker.internal

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -28,6 +28,7 @@ app/
     procedure.py          # run_procedure, ensure_procedure_accepted helpers
     admin/                # tenant_service, user_service
     basic_service.py      # basic GIS endpoints
+    features_service.py   # feature collections (nodes/arcs/links/connecs/gullies)
     crm_service.py        # hydrometer CRUD
     om/                   # flow, profile, mincut, dma, mapzones, waterbalance
     epa/                  # dscenario_service

--- a/docs/DEPLOYMENT_CHECKLIST.md
+++ b/docs/DEPLOYMENT_CHECKLIST.md
@@ -10,10 +10,10 @@ Use with [deploy/install.sh](../deploy/install.sh) (recommended), [deploy/.env.p
 - [ ] **DNS multi-tenant only**: `proxy_set_header Host $host;` (tenant id is the left label of the Host); apex `BASE_DOMAIN` → `${API_ROOT}/admin/*`; `*.BASE_DOMAIN` → `${API_ROOT}/v1/*` (default `API_ROOT=/giswater`).
 - [ ] **Single-tenant only**: `SINGLE_TENANT_ID` matches an existing `config/tenants/<id>.env`; admin and tenant API both reachable on the same host/IP under `${API_ROOT}/admin/*` and `${API_ROOT}/v1/*`.
 - [ ] **Secrets**: `ADMIN_PASSWORD` set; Keycloak secrets not in git; DB password least-privilege.
-- [ ] **Postgres**: version matches [compatibility table](../README.md#compatibility); backup/restore tested.
+- [ ] **Postgres / Giswater DB**: version matches [compatibility table](../README.md#compatibility) for this API release; backup/restore tested.
 - [ ] **Pool budget**: `N_tenants × DB_POOL_MAX_SIZE` within Postgres `max_connections`.
 - [ ] **Logging**: `LOG_DB_SAMPLE_RATE=1.0` for full API request audit; lower if the DB log table becomes hot. Use `LOG_HTTP_BODY_CAPTURE=false` only when you must avoid storing payload text; otherwise bodies are truncated via `LOG_DB_MAX_BODY_BYTES`.
-- [ ] **Readiness**: `GISWATER_DB_VERSION_CHECK=true` in prod if you want `/ready` to enforce min Giswater DB (see `GISWATER_DB_MIN_VERSION`).
+- [ ] **Readiness**: `GISWATER_DB_VERSION_CHECK=true` in prod if you want `/ready` to enforce min Giswater DB; set `GISWATER_DB_MIN_VERSION` to the floor you want.
 - [ ] **Gunicorn**: `WEB_CONCURRENCY` set for CPU/RAM; container `start_period` allows pool + DB connect.
 - [ ] **Probes**: liveness `GET ${API_ROOT}/health`; readiness per tenant `GET ${API_ROOT}/v1/ready` (503 if DB or version check fails).
 

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -64,7 +64,7 @@ Used only when evaluating tenant **`GET ${API_ROOT}/v1/ready`** (after the datab
 | Variable | Default | Description |
 | -------- | ------- | ----------- |
 | `GISWATER_DB_VERSION_CHECK` | `false` | When `true`, readiness compares `{DB_SCHEMA}.sys_version.giswater` to `GISWATER_DB_MIN_VERSION`. Returns **503** if missing or below minimum. |
-| `GISWATER_DB_MIN_VERSION` | `4.17.0` | Minimum Giswater DB version string for the check (parsed as dotted numeric components). Align with [README compatibility](../README.md#compatibility). Required ≥ 4.17.0 for the refactored `gw_fct_getfeatures` used by `/features`. |
+| `GISWATER_DB_MIN_VERSION` | `4.17.0` | Minimum Giswater DB version string for the check (parsed as dotted numeric components). Default matches [README compatibility](../README.md#compatibility). Override per deployment based on active endpoints. |
 
 ### Rate limiting
 
@@ -144,7 +144,7 @@ One file per tenant: `config/tenants/<tenant_id>.env`. The filename stem is the 
 | `API_ROUTING` | `false` | External routing (Valhalla) integration. |
 | `API_CRM` | `false` | CRM / hydrometer-style endpoints. |
 | `API_EPA` | `false` | EPA / dscenario endpoints. |
-| `API_FEATURES` | `false` | Feature collection endpoints (`/features/nodes`, `/features/arcs`, …). |
+| `API_FEATURES` | `false` | Feature collection endpoints (`/features/nodes`, `/features/arcs`, …; list, GeoJSON, by-id fields/form/geojson). Needs Giswater DB ≥ 4.17.0. |
 
 ### Database
 

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -64,7 +64,7 @@ Used only when evaluating tenant **`GET ${API_ROOT}/v1/ready`** (after the datab
 | Variable | Default | Description |
 | -------- | ------- | ----------- |
 | `GISWATER_DB_VERSION_CHECK` | `false` | When `true`, readiness compares `{DB_SCHEMA}.sys_version.giswater` to `GISWATER_DB_MIN_VERSION`. Returns **503** if missing or below minimum. |
-| `GISWATER_DB_MIN_VERSION` | `4.8.0` | Minimum Giswater DB version string for the check (parsed as dotted numeric components). Align with [README compatibility](../README.md#compatibility). |
+| `GISWATER_DB_MIN_VERSION` | `4.17.0` | Minimum Giswater DB version string for the check (parsed as dotted numeric components). Align with [README compatibility](../README.md#compatibility). Required ≥ 4.17.0 for the refactored `gw_fct_getfeatures` used by `/features`. |
 
 ### Rate limiting
 
@@ -144,6 +144,7 @@ One file per tenant: `config/tenants/<tenant_id>.env`. The filename stem is the 
 | `API_ROUTING` | `false` | External routing (Valhalla) integration. |
 | `API_CRM` | `false` | CRM / hydrometer-style endpoints. |
 | `API_EPA` | `false` | EPA / dscenario endpoints. |
+| `API_FEATURES` | `false` | Feature collection endpoints (`/features/nodes`, `/features/arcs`, …). |
 
 ### Database
 

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -15,7 +15,8 @@ There are **three independent version layers**. Keep them separate.
 - **One codebase serving tenants on different DB versions is normal.** Business
   logic lives in `gw_fct_*` DB functions, not in Python branches. The DB version
   is a *tenant capability*, surfaced via [`/ready`](../app/api/v1/endpoints/system.py)
-  and optionally gated by `GISWATER_DB_VERSION_CHECK`.
+  and optionally gated by `GISWATER_DB_VERSION_CHECK` /
+  `GISWATER_DB_MIN_VERSION` (see [README compatibility](../README.md#compatibility)).
 - **Additive Pydantic fields do not need a new URL version.** Adding optional
   response fields or new endpoints is a minor semver bump, still under `/v1`.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,7 +46,7 @@ def _materialize_tenants_dir() -> str:
     (tmp / "test.env").write_text(
         "API_BASIC=true\nAPI_PROFILE=true\nAPI_FLOW=true\nAPI_MINCUT=true\n"
         "API_WATER_BALANCE=true\nAPI_MAPZONES=true\nAPI_ROUTING=true\n"
-        "API_CRM=true\nAPI_EPA=true\n"
+        "API_CRM=true\nAPI_EPA=true\nAPI_FEATURES=true\n"
         f"DB_HOST={db_host}\nDB_PORT={db_port}\nDB_NAME={db_name}\n"
         f"DB_USER={db_user}\nDB_PASSWORD={db_password}\nDB_SCHEMA=public\n"
         f'DATABASE_URL="{db_url}"\n'

--- a/tests/fixtures/tenants/example.env
+++ b/tests/fixtures/tenants/example.env
@@ -7,6 +7,7 @@ API_MAPZONES=true
 API_ROUTING=true
 API_CRM=true
 API_EPA=true
+API_FEATURES=true
 
 DB_HOST=localhost
 DB_PORT=5432

--- a/tests/fixtures/tenants/test.env
+++ b/tests/fixtures/tenants/test.env
@@ -7,6 +7,7 @@ API_MAPZONES=true
 API_ROUTING=true
 API_CRM=true
 API_EPA=true
+API_FEATURES=true
 
 DB_HOST=localhost
 DB_PORT=5432

--- a/tests/test_auth_smoke.py
+++ b/tests/test_auth_smoke.py
@@ -45,7 +45,7 @@ def _tenant_env_body(auth_mode: str) -> str:
     return (
         "API_BASIC=true\nAPI_PROFILE=true\nAPI_FLOW=true\nAPI_MINCUT=true\n"
         "API_WATER_BALANCE=true\nAPI_MAPZONES=true\nAPI_ROUTING=true\n"
-        "API_CRM=true\nAPI_EPA=true\n"
+        "API_CRM=true\nAPI_EPA=true\nAPI_FEATURES=true\n"
         f"DB_HOST={db_host}\nDB_PORT={db_port}\nDB_NAME={db_name}\n"
         f"DB_USER={db_user}\nDB_PASSWORD={db_password}\nDB_SCHEMA={db_schema}\n"
         f'DATABASE_URL="{db_url}"\n'

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -159,25 +159,135 @@ def test_limit_is_honoured(client, default_params):
 
 
 def test_get_feature_by_id(client, default_params):
-    assert_ready(client)
+    _require_getfeatures_refactor(client, default_params)
 
-    listing = client.get(
-        api("/basic/getlist"),
-        params={**default_params, "tableName": "ve_node", "pageInfo": '{"limit": 1}'},
-    )
+    listing = client.get(api("/features/nodes"), params={**default_params, "limit": 1})
     assert listing.status_code == 200
-    fields = listing.json().get("body", {}).get("data", {}).get("fields") or []
-    if not fields:
+    features = listing.json().get("body", {}).get("data", {}).get("features") or []
+    if not features:
         pytest.skip("No nodes available to fetch by id")
 
-    node_id = fields[0].get("node_id")
+    node_id = features[0].get("node_id")
     assert node_id is not None
+    list_keys = set(features[0].keys())
 
     response = client.get(api(f"/features/nodes/{node_id}"), params=default_params)
     assert response.status_code == 200
     data = response.json()
     assert data["status"] == "Accepted"
-    assert "body" in data
+    feature = data["body"]["data"]["feature"]
+    assert feature["node_id"] == node_id
+    assert set(feature.keys()) == list_keys
+
+
+@pytest.mark.parametrize(
+    ("list_path", "id_field"),
+    [
+        ("/features/nodes", "node_id"),
+        ("/features/arcs", "arc_id"),
+        ("/features/links", "link_id"),
+        ("/features/connecs", "connec_id"),
+    ],
+)
+def test_get_feature_fields_by_id(client, default_params, list_path, id_field):
+    _require_getfeatures_refactor(client, default_params)
+
+    listing = client.get(api(list_path), params={**default_params, "limit": 1})
+    assert listing.status_code == 200
+    features = listing.json().get("body", {}).get("data", {}).get("features") or []
+    if not features:
+        pytest.skip(f"No features available at {list_path}")
+
+    feature_id = features[0][id_field]
+    list_keys = set(features[0].keys())
+    base_path = list_path.rstrip("/")
+
+    response = client.get(api(f"{base_path}/{feature_id}"), params=default_params)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "Accepted"
+    feature = data["body"]["data"]["feature"]
+    assert feature[id_field] == feature_id
+    assert set(feature.keys()) == list_keys
+
+
+@pytest.mark.parametrize(
+    ("list_path", "id_field"),
+    [
+        ("/features/nodes", "node_id"),
+        ("/features/arcs", "arc_id"),
+        ("/features/links", "link_id"),
+        ("/features/connecs", "connec_id"),
+    ],
+)
+def test_get_feature_form_by_id(client, default_params, list_path, id_field):
+    _require_getfeatures_refactor(client, default_params)
+
+    listing = client.get(api(list_path), params={**default_params, "limit": 1})
+    assert listing.status_code == 200
+    features = listing.json().get("body", {}).get("data", {}).get("features") or []
+    if not features:
+        pytest.skip(f"No features available at {list_path}")
+
+    feature_id = features[0][id_field]
+    base_path = list_path.rstrip("/")
+
+    response = client.get(api(f"{base_path}/{feature_id}/form"), params=default_params)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "Accepted"
+    assert "fields" in data["body"]["data"]
+
+
+@pytest.mark.parametrize(
+    ("list_path", "id_field"),
+    [
+        ("/features/nodes", "node_id"),
+        ("/features/arcs", "arc_id"),
+        ("/features/links", "link_id"),
+        ("/features/connecs", "connec_id"),
+    ],
+)
+def test_get_feature_geojson_by_id(client, default_params, list_path, id_field):
+    _require_getfeatures_refactor(client, default_params)
+
+    listing = client.get(api(list_path), params={**default_params, "limit": 1})
+    assert listing.status_code == 200
+    features = listing.json().get("body", {}).get("data", {}).get("features") or []
+    if not features:
+        pytest.skip(f"No features available at {list_path}")
+
+    feature_id = features[0][id_field]
+    base_path = list_path.rstrip("/")
+
+    response = client.get(api(f"{base_path}/{feature_id}/geojson"), params=default_params)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "Accepted"
+    body_data = data["body"]["data"]
+    assert body_data["type"] == "Feature"
+    assert body_data["geometry"] is not None
+    assert body_data["properties"][id_field] == feature_id
+
+
+def test_get_feature_by_id_not_found(client, default_params):
+    _require_getfeatures_refactor(client, default_params)
+
+    response = client.get(api("/features/arcs/__nope__"), params=default_params)
+    assert response.status_code == 404
+    assert "detail" in response.json()
+
+
+def test_arcs_geojson_not_swallowed_by_arc_id(client, default_params):
+    """Route order: /arcs/geojson must not match /arcs/{arc_id}."""
+    _require_getfeatures_refactor(client, default_params)
+
+    response = client.get(api("/features/arcs/geojson"), params={**default_params, "limit": 5})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "Accepted"
+    assert data["body"]["data"].get("type") == "FeatureCollection"
 
 
 def test_features_disabled_returns_404(client, default_params):

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,0 +1,217 @@
+"""
+Copyright © 2026 by BGEO. All rights reserved.
+The program is free software: you can redistribute it and/or modify it under the terms of the GNU
+General Public License as published by the Free Software Foundation, either version 3 of the License,
+or (at your option) any later version.
+"""
+
+from dataclasses import replace
+
+import pytest
+from tests.helpers import api, assert_ready
+
+
+def _db_version(client, default_params) -> str | None:
+    response = client.get(api("/features/nodes"), params={**default_params, "limit": 1})
+    if response.status_code == 200:
+        version = response.json().get("version") or {}
+        return version.get("db")
+    body = response.json()
+    version = body.get("version")
+    if isinstance(version, dict):
+        return version.get("db")
+    if isinstance(version, str):
+        return version
+    return None
+
+
+def _version_tuple(version: str) -> tuple[int, ...]:
+    parts: list[int] = []
+    for part in version.split("."):
+        digits = "".join(ch for ch in part if ch.isdigit())
+        parts.append(int(digits) if digits else 0)
+    return tuple(parts)
+
+
+def _require_getfeatures_refactor(client, default_params) -> None:
+    """gw_fct_getfeatures featureType/outputFormat ships in Giswater DB 4.17.0+."""
+    assert_ready(client)
+    version = _db_version(client, default_params)
+    if version is None:
+        pytest.skip("Could not determine Giswater DB version")
+    if _version_tuple(version) < (4, 17, 0):
+        pytest.skip(f"Requires Giswater DB >= 4.17.0 for gw_fct_getfeatures refactor (got {version})")
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/features/nodes",
+        "/features/arcs",
+        "/features/links",
+        "/features/connecs",
+    ],
+)
+def test_list_features(client, default_params, path):
+    _require_getfeatures_refactor(client, default_params)
+
+    response = client.get(api(path), params={**default_params, "limit": 10})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "Accepted"
+    assert "body" in data
+    assert "data" in data["body"]
+    assert "features" in data["body"]["data"]
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/features/nodes/geojson",
+        "/features/arcs/geojson",
+        "/features/links/geojson",
+        "/features/connecs/geojson",
+    ],
+)
+def test_list_features_geojson(client, default_params, path):
+    _require_getfeatures_refactor(client, default_params)
+
+    response = client.get(api(path), params={**default_params, "limit": 10})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "Accepted"
+    body_data = data["body"]["data"]
+    assert body_data.get("type") == "FeatureCollection"
+    assert "features" in body_data
+
+
+def test_nodes_geojson_not_swallowed_by_node_id(client, default_params):
+    """Route order: /nodes/geojson must not match /nodes/{node_id}."""
+    _require_getfeatures_refactor(client, default_params)
+
+    response = client.get(api("/features/nodes/geojson"), params={**default_params, "limit": 5})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "Accepted"
+    assert data["body"]["data"].get("type") == "FeatureCollection"
+
+
+def test_arcs_filter_by_dma_id(client, default_params):
+    _require_getfeatures_refactor(client, default_params)
+
+    response = client.get(api("/features/arcs"), params={**default_params, "dma_id": 2, "limit": 50})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "Accepted"
+    features = data["body"]["data"].get("features") or []
+    for feature in features:
+        assert feature.get("dma_id") == 2
+
+
+def test_connecs_filter_by_sector_id(client, default_params):
+    _require_getfeatures_refactor(client, default_params)
+
+    response = client.get(api("/features/connecs"), params={**default_params, "sector_id": 5, "limit": 50})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "Accepted"
+    features = data["body"]["data"].get("features") or []
+    for feature in features:
+        assert feature.get("sector_id") == 5
+
+
+def test_nodes_filter_by_sys_type_valve(client, default_params):
+    _require_getfeatures_refactor(client, default_params)
+
+    response = client.get(api("/features/nodes"), params={**default_params, "sys_type": "VALVE", "limit": 50})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "Accepted"
+    features = data["body"]["data"].get("features") or []
+    for feature in features:
+        assert feature.get("sys_type") == "VALVE"
+
+
+def test_unknown_filter_returns_422(client, default_params):
+    assert_ready(client)
+
+    response = client.get(api("/features/nodes"), params={**default_params, "nodetype": "VALVE", "limit": 10})
+
+    assert response.status_code == 422
+
+
+def test_limit_is_honoured(client, default_params):
+    _require_getfeatures_refactor(client, default_params)
+
+    response = client.get(api("/features/arcs"), params={**default_params, "limit": 3})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "Accepted"
+    features = data["body"]["data"].get("features") or []
+    assert len(features) <= 3
+
+
+def test_get_feature_by_id(client, default_params):
+    assert_ready(client)
+
+    listing = client.get(
+        api("/basic/getlist"),
+        params={**default_params, "tableName": "ve_node", "pageInfo": '{"limit": 1}'},
+    )
+    assert listing.status_code == 200
+    fields = listing.json().get("body", {}).get("data", {}).get("fields") or []
+    if not fields:
+        pytest.skip("No nodes available to fetch by id")
+
+    node_id = fields[0].get("node_id")
+    assert node_id is not None
+
+    response = client.get(api(f"/features/nodes/{node_id}"), params=default_params)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "Accepted"
+    assert "body" in data
+
+
+def test_features_disabled_returns_404(client, default_params):
+    assert_ready(client)
+
+    from app.tenancy import state
+
+    assert state.registry is not None
+    tenant = state.registry.get("test")
+    assert tenant is not None
+    original = tenant.settings
+    tenant.settings = replace(original, api_features=False)
+    try:
+        response = client.get(api("/features/nodes"), params={**default_params, "limit": 1})
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Feature disabled"
+    finally:
+        tenant.settings = original
+
+
+@pytest.mark.ud
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/features/gullies",
+        "/features/gullies/geojson",
+    ],
+)
+def test_list_gullies_ud(client, default_params, path):
+    _require_getfeatures_refactor(client, default_params)
+
+    response = client.get(api(path), params={**default_params, "limit": 10})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "Accepted"
+    assert "body" in data


### PR DESCRIPTION
- **New `/features` module** — list / GeoJSON collection / by-id fields / form / GeoJSON Feature for **nodes, arcs, links, connecs, gullies**
- **Backed by** `gw_fct_getfeatures` (`featureType` / `outputFormat`) + form via `gw_fct_getinfofromid`
- **Typed filters** + order/limit/coordinates; schemas in `feature_models.py`, service in `features_service.py`
- **Feature-flagged** with `API_FEATURES` (default off)
- **DB floor bumped** — `GISWATER_DB_MIN_VERSION` default `4.8.0` → `4.17.0`; docs say **1.7.x → DB ≥ 4.17**
- **Deprecated** `GET /om/dmas/{dma_id}/connecs` → prefer `/features/connecs?dma_id=…`
- **Tests** for the new endpoints; CI/env/docs/changelog updated accordingly